### PR TITLE
Feat/backend sprint workflow services

### DIFF
--- a/backend/src/services/sprintService.ts
+++ b/backend/src/services/sprintService.ts
@@ -1,0 +1,199 @@
+import Sprint from '../models/Sprint.js';
+import Issue from '../models/Issue.js';
+import Project from '../models/Project.js';
+import { notifyProjectMembers } from '../utils/notificationUtils.js';
+
+const createError = (message: string, statusCode: number) => {
+  const err: any = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+};
+
+class SprintService {
+  /**
+   * Create a new sprint for a project.
+   * Validates startDate < endDate if both are provided.
+   */
+  async createSprint(projectId: string, data: any): Promise<Sprint> {
+    if (data.startDate && data.endDate) {
+      const start = new Date(data.startDate);
+      const end = new Date(data.endDate);
+      if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+        throw createError('Invalid startDate or endDate', 400);
+      }
+      if (start >= end) {
+        throw createError('startDate must be strictly before endDate', 400);
+      }
+    }
+
+    const project = await Project.findById(projectId);
+    if (!project) {
+      throw createError('Project not found', 404);
+    }
+
+    return Sprint.create({
+      projectId,
+      organizationId: project.organizationId || null,
+      name: data.name,
+      goal: data.goal,
+      startDate: data.startDate || null,
+      endDate: data.endDate || null,
+      state: 'created',
+    });
+  }
+
+  /**
+   * Start a sprint. Enforces single-active-sprint invariant (409 if one already active).
+   * Sets startDate to now if not already set. Emits sprint_started notifications.
+   */
+  async startSprint(sprintId: string, userId: string): Promise<Sprint> {
+    const sprint = await Sprint.findById(sprintId);
+    if (!sprint) {
+      throw createError('Sprint not found', 404);
+    }
+
+    if (sprint.state !== 'created') {
+      throw createError(`Cannot start a sprint in '${sprint.state}' state`, 400);
+    }
+
+    // Enforce single active sprint per project
+    const activeSprint = await Sprint.findActiveByProject(sprint.projectId);
+    if (activeSprint) {
+      throw createError('A sprint is already active in this project', 409);
+    }
+
+    const updateData: any = { state: 'active' };
+    if (!sprint.startDate) {
+      updateData.startDate = new Date();
+    }
+
+    const updated = await Sprint.update(sprintId, updateData);
+
+    // Emit sprint_started notifications to all project members
+    try {
+      await notifyProjectMembers(sprint.projectId, {
+        type: 'sprint_started',
+        title: `Sprint Started: ${sprint.name}`,
+        message: `Sprint "${sprint.name}" has been started.`,
+        relatedEntityType: 'sprint',
+        relatedEntityId: sprintId,
+      });
+    } catch (notifErr) {
+      console.error('Failed to send sprint_started notifications:', notifErr);
+    }
+
+    return updated;
+  }
+
+  /**
+   * Close a sprint. Sets endDate if unset. Moves incomplete issues to backlog.
+   * Records completedStoryPoints and completedIssueCount.
+   */
+  async closeSprint(sprintId: string, userId: string): Promise<Sprint> {
+    const sprint = await Sprint.findById(sprintId);
+    if (!sprint) {
+      throw createError('Sprint not found', 404);
+    }
+
+    if (sprint.state !== 'active') {
+      throw createError(`Cannot close a sprint in '${sprint.state}' state`, 400);
+    }
+
+    // Fetch all issues in this sprint
+    const sprintIssues = await Issue.findAll({ sprintId });
+
+    // Determine done-category states from project workflow
+    let doneStates: Set<string> = new Set(['done']);
+    try {
+      const project = await Project.findById(sprint.projectId);
+      if (project?.workflow?.states) {
+        const doneStateNames = project.workflow.states
+          .filter((s: any) => s.category === 'done')
+          .map((s: any) => s.name);
+        if (doneStateNames.length > 0) {
+          doneStates = new Set(doneStateNames);
+        }
+      }
+    } catch {
+      // fallback: use 'done' as the only done state
+    }
+
+    const completedIssues = sprintIssues.filter((i) => doneStates.has(i.status));
+    const incompleteIssues = sprintIssues.filter((i) => !doneStates.has(i.status));
+
+    // Move incomplete issues to backlog (clear sprintId)
+    await Promise.all(
+      incompleteIssues.map((issue) => Issue.update(issue.id, { sprintId: null }))
+    );
+
+    // Compute stats
+    const completedStoryPoints = completedIssues.reduce(
+      (sum, i) => sum + (typeof i.storyPoints === 'number' ? i.storyPoints : 0),
+      0
+    );
+    const completedIssueCount = completedIssues.length;
+
+    const updateData: any = {
+      state: 'closed',
+      completedStoryPoints,
+      completedIssueCount,
+    };
+    if (!sprint.endDate) {
+      updateData.endDate = new Date();
+    }
+
+    const updated = await Sprint.update(sprintId, updateData);
+
+    // Emit sprint_closed notifications
+    try {
+      await notifyProjectMembers(sprint.projectId, {
+        type: 'sprint_closed',
+        title: `Sprint Closed: ${sprint.name}`,
+        message: `Sprint "${sprint.name}" has been closed. ${completedIssueCount} issues completed.`,
+        relatedEntityType: 'sprint',
+        relatedEntityId: sprintId,
+      });
+    } catch (notifErr) {
+      console.error('Failed to send sprint_closed notifications:', notifErr);
+    }
+
+    return updated;
+  }
+
+  /**
+   * Get backlog issues for a project — issues with no sprintId, ordered by position.
+   */
+  async getBacklog(projectId: string): Promise<any[]> {
+    const project = await Project.findById(projectId);
+    if (!project) {
+      throw createError('Project not found', 404);
+    }
+
+    const issues = await Issue.findAll({
+      projectId,
+      orderBy: 'position',
+      orderDir: 'ASC',
+    });
+
+    return issues.filter((i) => !i.sprintId);
+  }
+
+  /**
+   * Add an issue to a sprint by setting its sprintId.
+   */
+  async addIssueToSprint(sprintId: string, issueId: string): Promise<any> {
+    const sprint = await Sprint.findById(sprintId);
+    if (!sprint) {
+      throw createError('Sprint not found', 404);
+    }
+
+    const issue = await Issue.findById(issueId);
+    if (!issue) {
+      throw createError('Issue not found', 404);
+    }
+
+    return Issue.update(issueId, { sprintId });
+  }
+}
+
+export default new SprintService();

--- a/backend/src/services/workflowService.ts
+++ b/backend/src/services/workflowService.ts
@@ -1,0 +1,139 @@
+import Project from '../models/Project.js';
+import Issue from '../models/Issue.js';
+
+const createError = (message: string, statusCode: number) => {
+  const err: any = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+};
+
+interface WorkflowState {
+  name: string;
+  category: 'todo' | 'in_progress' | 'done';
+  transitions: string[];
+}
+
+interface WorkflowDefinition {
+  states: WorkflowState[];
+}
+
+const DEFAULT_WORKFLOW: WorkflowDefinition = {
+  states: [
+    { name: 'To Do', category: 'todo', transitions: ['In Progress'] },
+    { name: 'In Progress', category: 'in_progress', transitions: ['In Review', 'To Do'] },
+    { name: 'In Review', category: 'in_progress', transitions: ['In Progress', 'Done'] },
+    { name: 'Done', category: 'done', transitions: [] },
+  ],
+};
+
+class WorkflowService {
+  /**
+   * Get the workflow for a project. Returns the default workflow if none is set.
+   */
+  async getWorkflow(projectId: string): Promise<WorkflowDefinition> {
+    const project = await Project.findById(projectId);
+    if (!project) {
+      throw createError('Project not found', 404);
+    }
+
+    return project.workflow || DEFAULT_WORKFLOW;
+  }
+
+  /**
+   * Update the workflow for a project.
+   * Validates that all states have a category field.
+   */
+  async updateWorkflow(projectId: string, workflowDef: WorkflowDefinition): Promise<WorkflowDefinition> {
+    const project = await Project.findById(projectId);
+    if (!project) {
+      throw createError('Project not found', 404);
+    }
+
+    if (!workflowDef || !Array.isArray(workflowDef.states)) {
+      throw createError('Workflow must have a states array', 400);
+    }
+
+    const validCategories = new Set(['todo', 'in_progress', 'done']);
+    for (const state of workflowDef.states) {
+      if (!state.name || typeof state.name !== 'string') {
+        throw createError('Each workflow state must have a name', 400);
+      }
+      if (!state.category || !validCategories.has(state.category)) {
+        throw createError(
+          `State "${state.name}" must have a valid category: todo, in_progress, or done`,
+          400
+        );
+      }
+      if (!Array.isArray(state.transitions)) {
+        throw createError(`State "${state.name}" must have a transitions array`, 400);
+      }
+    }
+
+    await Project.update(projectId, { workflow: workflowDef });
+    return workflowDef;
+  }
+
+  /**
+   * Validate whether a transition from currentState to targetState is permitted.
+   * Throws 422 if the transition is not allowed.
+   */
+  async validateTransition(
+    projectId: string,
+    currentState: string,
+    targetState: string
+  ): Promise<void> {
+    const workflow = await this.getWorkflow(projectId);
+
+    const stateObj = workflow.states.find((s) => s.name === currentState);
+    if (!stateObj) {
+      throw createError(`Current state "${currentState}" is not defined in the workflow`, 422);
+    }
+
+    if (!stateObj.transitions.includes(targetState)) {
+      throw createError(
+        `Transition from "${currentState}" to "${targetState}" is not permitted`,
+        422
+      );
+    }
+  }
+
+  /**
+   * Delete a workflow state. Throws 409 if any issues are currently in that state.
+   */
+  async deleteState(projectId: string, stateName: string): Promise<WorkflowDefinition> {
+    const project = await Project.findById(projectId);
+    if (!project) {
+      throw createError('Project not found', 404);
+    }
+
+    const workflow: WorkflowDefinition = project.workflow || DEFAULT_WORKFLOW;
+
+    const stateExists = workflow.states.some((s) => s.name === stateName);
+    if (!stateExists) {
+      throw createError(`State "${stateName}" not found in workflow`, 404);
+    }
+
+    // Check if any issues are currently in this state
+    const issuesInState = await Issue.findAll({ projectId, status: stateName });
+    if (issuesInState.length > 0) {
+      throw createError(
+        `Cannot delete state "${stateName}": ${issuesInState.length} issue(s) are currently in this state`,
+        409
+      );
+    }
+
+    const updatedWorkflow: WorkflowDefinition = {
+      states: workflow.states
+        .filter((s) => s.name !== stateName)
+        .map((s) => ({
+          ...s,
+          transitions: s.transitions.filter((t) => t !== stateName),
+        })),
+    };
+
+    await Project.update(projectId, { workflow: updatedWorkflow });
+    return updatedWorkflow;
+  }
+}
+
+export default new WorkflowService();


### PR DESCRIPTION
This pull request introduces two new service classes, `SprintService` and `WorkflowService`, to encapsulate business logic for managing sprints and workflows in the backend. These services provide methods for creating, starting, and closing sprints, managing backlog and sprint issues, and handling project workflows, including validation and state transitions. The changes improve code organization, enforce business rules, and add validation and notification logic.

**Sprint management enhancements:**

* Added `SprintService` class with methods to create, start, and close sprints, enforcing business rules such as single active sprint per project, validating dates, and moving incomplete issues to backlog on sprint close. Notifications are sent to project members on sprint start/close. (`backend/src/services/sprintService.ts`, [backend/src/services/sprintService.tsR1-R199](diffhunk://#diff-cd6255bcff7f0b54a0945ed6ea8435d4eb3728439cfd4aac0d3225cf7dab8243R1-R199))
* Implemented backlog management and issue assignment to sprints, with validation for project and issue existence. (`backend/src/services/sprintService.ts`, [backend/src/services/sprintService.tsR1-R199](diffhunk://#diff-cd6255bcff7f0b54a0945ed6ea8435d4eb3728439cfd4aac0d3225cf7dab8243R1-R199))

**Workflow management enhancements:**

* Added `WorkflowService` class to manage project workflows, including retrieving and updating workflows with validation for state structure and allowed categories. Provides a default workflow if none is set. (`backend/src/services/workflowService.ts`, [backend/src/services/workflowService.tsR1-R139](diffhunk://#diff-ed1e39e5a9e44e11d4c235855fd67b29db38837c793c6e5cd18a64698fc47ddaR1-R139))
* Implemented workflow state transition validation, ensuring only permitted transitions are allowed, and added logic to prevent deletion of workflow states if issues are currently in that state. (`backend/src/services/workflowService.ts`, [backend/src/services/workflowService.tsR1-R139](diffhunk://#diff-ed1e39e5a9e44e11d4c235855fd67b29db38837c793c6e5cd18a64698fc47ddaR1-R139))