### PR TITLE
add property-based tests for Issue model validation and serialization

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -66,27 +66,72 @@
     "typescript": "^6.0.2"
   },
   "jest": {
-    "testEnvironment": "node",
-    "transform": {
-      "^.+\\.tsx?$": [
-        "ts-jest",
-        {
-          "useESM": true,
-          "tsconfig": "tsconfig.json"
-        }
-      ]
-    },
-    "extensionsToTreatAsEsm": [
-      ".ts"
-    ],
-    "moduleNameMapper": {
-      "^(\\.{1,2}/.*)\\.js$": "$1"
-    },
-    "setupFilesAfterEnv": [
-      "<rootDir>/tests/setup.mjs"
-    ],
-    "testMatch": [
-      "**/tests/**/*.test.mjs"
+    "projects": [
+      {
+        "displayName": "integration",
+        "testEnvironment": "node",
+        "transform": {
+          "^.+\\.tsx?$": [
+            "ts-jest",
+            {
+              "useESM": true,
+              "tsconfig": {
+                "module": "NodeNext",
+                "moduleResolution": "NodeNext",
+                "target": "ES2022",
+                "esModuleInterop": true,
+                "resolveJsonModule": true,
+                "strict": false,
+                "noImplicitAny": false,
+                "skipLibCheck": true
+              }
+            }
+          ]
+        },
+        "extensionsToTreatAsEsm": [
+          ".ts"
+        ],
+        "moduleNameMapper": {
+          "^(\\.{1,2}/.*)\\.js$": "$1"
+        },
+        "setupFilesAfterEnv": [
+          "<rootDir>/tests/setup.mjs"
+        ],
+        "testMatch": [
+          "**/tests/**/*.test.mjs"
+        ]
+      },
+      {
+        "displayName": "properties",
+        "testEnvironment": "node",
+        "transform": {
+          "^.+\\.tsx?$": [
+            "ts-jest",
+            {
+              "useESM": true,
+              "tsconfig": {
+                "module": "NodeNext",
+                "moduleResolution": "NodeNext",
+                "target": "ES2022",
+                "esModuleInterop": true,
+                "resolveJsonModule": true,
+                "strict": false,
+                "noImplicitAny": false,
+                "skipLibCheck": true
+              }
+            }
+          ]
+        },
+        "extensionsToTreatAsEsm": [
+          ".ts"
+        ],
+        "moduleNameMapper": {
+          "^(\\.{1,2}/.*)\\.js$": "$1"
+        },
+        "testMatch": [
+          "**/tests/properties/**/*.test.ts"
+        ]
+      }
     ]
   }
 }

--- a/backend/tests/properties/issueProperties.test.ts
+++ b/backend/tests/properties/issueProperties.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Property-based tests for the Issue model.
+ * Feature: jira-level-platform
+ * Validates: Requirements 1.5, 1.7, 1.8
+ */
+
+import * as fc from 'fast-check';
+import Issue from '../../src/models/Issue.js';
+import { describe, it } from 'node:test';
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+const issueTypeArb = fc.constantFrom('task', 'bug', 'epic');
+
+const bugSeverityArb = fc.constantFrom('critical', 'high', 'medium', 'low');
+
+const storyPointsArb = fc.oneof(
+  fc.constant(null),
+  fc.nat({ max: 100 }),
+);
+
+const childIssueIdsArb = fc.array(
+  fc.stringMatching(/^[a-f0-9]{24}$/),
+  { maxLength: 10 },
+);
+
+// Arbitrary for a plain Issue-like data object (no DB interaction needed)
+const issueDataArb = fc.record({
+  issueType: issueTypeArb,
+  bugSeverity: fc.oneof(fc.constant(null), fc.constant(undefined), bugSeverityArb),
+  storyPoints: storyPointsArb,
+  childIssueIds: childIssueIdsArb,
+});
+
+// ---------------------------------------------------------------------------
+// Property 1: Issue type field round-trip
+// Feature: jira-level-platform, Property 1: Issue type field round-trip
+// ---------------------------------------------------------------------------
+
+describe('Property 1: Issue type field round-trip', () => {
+  it('serializing and deserializing an Issue preserves issueType, bugSeverity, storyPoints, and childIssueIds', () => {
+    fc.assert(
+      fc.property(issueDataArb, (data) => {
+        const issue = new Issue(data);
+        const serialized = JSON.stringify(issue);
+        const deserialized = JSON.parse(serialized);
+
+        // issueType must survive the round-trip
+        expect(deserialized.issueType).toBe(issue.issueType);
+
+        // storyPoints must survive the round-trip
+        expect(deserialized.storyPoints).toBe(issue.storyPoints);
+
+        // childIssueIds must survive the round-trip (deep equality)
+        expect(deserialized.childIssueIds).toEqual(issue.childIssueIds);
+
+        // bugSeverity: null/undefined both serialize to absent; treat both as null
+        const expectedSeverity = issue.bugSeverity ?? null;
+        const actualSeverity = deserialized.bugSeverity ?? null;
+        expect(actualSeverity).toBe(expectedSeverity);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 2: Issue key format invariant
+// Feature: jira-level-platform, Property 2: Issue key format invariant
+// ---------------------------------------------------------------------------
+
+// Arbitrary for a valid project key: 1–6 uppercase alphanumeric characters
+const projectKeyArb = fc.stringMatching(/^[A-Z0-9]{1,6}$/);
+
+// Arbitrary for a positive counter (issue number)
+const counterArb = fc.integer({ min: 1, max: 999999 });
+
+describe('Property 2: Issue key format invariant', () => {
+  it('issueKey built from projectKey + counter always matches /^[A-Z0-9]+-\\d+$/', () => {
+    fc.assert(
+      fc.property(projectKeyArb, counterArb, (projectKey, counter) => {
+        const issueKey = `${projectKey}-${counter}`;
+        const issue = new Issue({ issueKey });
+
+        expect(issue.issueKey).toMatch(/^[A-Z0-9]+-\d+$/);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 3: Invalid issue type rejected
+// Feature: jira-level-platform, Property 3: Invalid issue type rejected
+// ---------------------------------------------------------------------------
+
+const validIssueTypes = new Set(['task', 'bug', 'epic']);
+
+// Arbitrary for strings that are NOT valid issue types
+const invalidIssueTypeArb = fc.string({ minLength: 1 }).filter(
+  (s) => !validIssueTypes.has(s),
+);
+
+describe('Property 3: Invalid issue type rejected', () => {
+  it('Issue.validateCreate() returns errors for any issueType not in {task, bug, epic}', () => {
+    fc.assert(
+      fc.property(invalidIssueTypeArb, (invalidType) => {
+        const errors = Issue.validateCreate({
+          title: 'Test Issue',
+          projectId: 'proj123',
+          createdBy: 'user123',
+          issueType: invalidType,
+        });
+
+        // Must have at least one error mentioning issueType
+        expect(errors.length).toBeGreaterThan(0);
+        const hasIssueTypeError = errors.some((e: string) =>
+          e.toLowerCase().includes('issuetype') || e.toLowerCase().includes('issue_type'),
+        );
+        expect(hasIssueTypeError).toBe(true);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});


### PR DESCRIPTION
This pull request introduces property-based testing for the `Issue` model and updates the Jest configuration to support these tests. The main changes are the addition of a new test suite for property-based tests and the configuration of Jest to run these tests in a dedicated project.

**Testing improvements:**

* Added a new property-based test suite in `tests/properties/issueProperties.test.ts` to validate key invariants and behaviors of the `Issue` model, including serialization round-trip, issue key formatting, and validation of allowed issue types.

**Test configuration:**

* Updated `backend/package.json` to define multiple Jest projects, including a new "properties" project targeting property-based tests in `tests/properties/`. This includes custom `ts-jest` settings and test matching patterns. [[1]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R69-R87) [[2]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5R103-R135)