### PR TITLE
chore: reduce numRuns in property-based tests to optimize performance

### DIFF
--- a/backend/tests/properties/boardProperties.test.ts
+++ b/backend/tests/properties/boardProperties.test.ts
@@ -87,7 +87,7 @@ describe('Property 4: Board reorder set invariant', () => {
 
         expect(setsEqual(before, after)).toBe(true);
       }),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -107,7 +107,7 @@ describe('Property 4: Board reorder set invariant', () => {
           expect(() => reorder(unique, tampered)).toThrow();
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -126,7 +126,7 @@ describe('Property 4: Board reorder set invariant', () => {
           expect(() => reorder(unique, truncated)).toThrow();
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });
@@ -157,7 +157,7 @@ describe('Property 5: Board reorder position uniqueness', () => {
         const positionSet = new Set(positions);
         expect(positionSet.size).toBe(positions.length);
       }),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -173,7 +173,7 @@ describe('Property 5: Board reorder position uniqueness', () => {
           expect(sorted[i]).toBe(i);
         }
       }),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -188,7 +188,7 @@ describe('Property 5: Board reorder position uniqueness', () => {
           expect(result[i].position).toBe(i);
         }
       }),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 });

--- a/backend/tests/properties/issueProperties.test.ts
+++ b/backend/tests/properties/issueProperties.test.ts
@@ -6,7 +6,6 @@
 
 import * as fc from 'fast-check';
 import Issue from '../../src/models/Issue.js';
-import { describe, it } from 'node:test';
 
 // ---------------------------------------------------------------------------
 // Arbitraries
@@ -61,7 +60,7 @@ describe('Property 1: Issue type field round-trip', () => {
         const actualSeverity = deserialized.bugSeverity ?? null;
         expect(actualSeverity).toBe(expectedSeverity);
       }),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });
@@ -86,7 +85,7 @@ describe('Property 2: Issue key format invariant', () => {
 
         expect(issue.issueKey).toMatch(/^[A-Z0-9]+-\d+$/);
       }),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });
@@ -121,7 +120,7 @@ describe('Property 3: Invalid issue type rejected', () => {
         );
         expect(hasIssueTypeError).toBe(true);
       }),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });

--- a/backend/tests/properties/notificationProperties.test.ts
+++ b/backend/tests/properties/notificationProperties.test.ts
@@ -180,7 +180,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
           expect(notifications.length).toBe(uniqueMemberCount);
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -210,7 +210,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
           expect(notifications.length).toBe(uniqueMemberCount);
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -235,7 +235,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
           expect(uniqueRecipients.size).toBe(recipientIds.length);
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -259,7 +259,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -290,7 +290,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -315,7 +315,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -326,7 +326,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
         const notifications = notifySprintStarted([], sprintId, projectId, sprintName);
         expect(notifications.length).toBe(0);
       }),
-      { numRuns: 50 },
+      { numRuns: 25 },
     );
   });
 
@@ -343,7 +343,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
           expect(notifications.length).toBe(0);
         },
       ),
-      { numRuns: 50 },
+      { numRuns: 25 },
     );
   });
 
@@ -373,7 +373,7 @@ describe('Property 26: Notification fan-out for sprint events', () => {
           expect(notifications.length).toBe(uniqueCount);
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });

--- a/backend/tests/properties/searchProperties.test.ts
+++ b/backend/tests/properties/searchProperties.test.ts
@@ -218,7 +218,7 @@ describe('Property 6: Search filter correctness invariant', () => {
           }
         },
       ),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -240,7 +240,7 @@ describe('Property 6: Search filter correctness invariant', () => {
           }
         },
       ),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -254,7 +254,7 @@ describe('Property 6: Search filter correctness invariant', () => {
           expect(results.length).toBe(issues.length);
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -271,7 +271,7 @@ describe('Property 6: Search filter correctness invariant', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -288,7 +288,7 @@ describe('Property 6: Search filter correctness invariant', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -305,7 +305,7 @@ describe('Property 6: Search filter correctness invariant', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });
@@ -344,7 +344,7 @@ describe('Property 7: Search filter monotonicity', () => {
           expect(isSubset(r1, r2)).toBe(true);
         },
       ),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -364,7 +364,7 @@ describe('Property 7: Search filter monotonicity', () => {
           expect(isSubset(r1, r2)).toBe(true);
         },
       ),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -384,7 +384,7 @@ describe('Property 7: Search filter monotonicity', () => {
           expect(isSubset(r1, r2)).toBe(true);
         },
       ),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -404,7 +404,7 @@ describe('Property 7: Search filter monotonicity', () => {
           expect(isSubset(r1, r2)).toBe(true);
         },
       ),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -426,7 +426,7 @@ describe('Property 7: Search filter monotonicity', () => {
           expect(isSubset(r1, r2)).toBe(true);
         },
       ),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 
@@ -453,7 +453,7 @@ describe('Property 7: Search filter monotonicity', () => {
           expect(isSubset(r1, r2)).toBe(true);
         },
       ),
-      { numRuns: 200 },
+      { numRuns: 25 },
     );
   });
 });

--- a/backend/tests/properties/sprintProperties.test.ts
+++ b/backend/tests/properties/sprintProperties.test.ts
@@ -5,7 +5,6 @@
  */
 
 import * as fc from 'fast-check';
-import { describe, it, beforeEach, mock } from 'node:test';
 import assert from 'node:assert/strict';
 
 // ---------------------------------------------------------------------------
@@ -65,7 +64,7 @@ const issueStatusArb = fc.constantFrom('To Do', 'In Progress', 'In Review', 'Don
 
 const issueArb = (sprintId: string) =>
   fc.record({
-    id: fc.hexaString({ minLength: 24, maxLength: 24 }),
+    id: fc.stringMatching(/^[a-f0-9]{24}$/),
     sprintId: fc.constant(sprintId),
     status: issueStatusArb,
   });
@@ -79,32 +78,33 @@ describe('Property 10: Sprint date ordering invariant', () => {
   it('rejects any startDate >= endDate', () => {
     fc.assert(
       fc.property(dateArb, dateArb, (d1, d2) => {
+        fc.pre(!isNaN(d1.getTime()) && !isNaN(d2.getTime()));
         // Case: startDate >= endDate — must be rejected
         const [later, earlier] = d1 >= d2 ? [d1, d2] : [d2, d1];
         // When start === end or start > end, validation must fail
         const errorWhenEqual = validateSprintDates(later, earlier);
         assert.ok(
           errorWhenEqual !== null,
-          `Expected error for startDate=${later.toISOString()} >= endDate=${earlier.toISOString()}`,
+          `Expected error for startDate >= endDate`,
         );
       }),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
   it('accepts any startDate strictly before endDate', () => {
     fc.assert(
       fc.property(dateArb, dateArb, (d1, d2) => {
-        fc.pre(d1.getTime() !== d2.getTime());
+        fc.pre(d1.getTime() !== d2.getTime() && !isNaN(d1.getTime()) && !isNaN(d2.getTime()));
         const [earlier, later] = d1 < d2 ? [d1, d2] : [d2, d1];
         const error = validateSprintDates(earlier, later);
         assert.equal(
           error,
           null,
-          `Expected no error for startDate=${earlier.toISOString()} < endDate=${later.toISOString()}`,
+          `Expected no error for valid date range`,
         );
       }),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });
@@ -140,7 +140,7 @@ describe('Property 11: Single active sprint invariant', () => {
           assert.equal(thrownMessage, 'A sprint is already active in this project');
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -169,7 +169,7 @@ describe('Property 11: Single active sprint invariant', () => {
           );
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });
@@ -200,7 +200,7 @@ describe('Property 12: Sprint state machine ordering', () => {
           );
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -245,7 +245,7 @@ describe('Property 12: Sprint state machine ordering', () => {
           );
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });
@@ -281,7 +281,7 @@ describe('Property 13: Sprint close moves incomplete issues to backlog', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -306,7 +306,7 @@ describe('Property 13: Sprint close moves incomplete issues to backlog', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -339,7 +339,7 @@ describe('Property 13: Sprint close moves incomplete issues to backlog', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });

--- a/backend/tests/properties/workflowProperties.test.ts
+++ b/backend/tests/properties/workflowProperties.test.ts
@@ -155,7 +155,7 @@ describe('Property 8: Workflow transition safety', () => {
           expect(definedStateNames.has(finalStatus)).toBe(true);
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -181,7 +181,7 @@ describe('Property 8: Workflow transition safety', () => {
           // null means transition was not permitted — that is also safe
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -209,7 +209,7 @@ describe('Property 8: Workflow transition safety', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 });
@@ -245,7 +245,7 @@ describe('Property 9: Workflow state completeness', () => {
           }
         },
       ),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 
@@ -259,7 +259,7 @@ describe('Property 9: Workflow state completeness', () => {
           expect(validCategories.has(state.category)).toBe(true);
         }
       }),
-      { numRuns: 100 },
+      { numRuns: 25 },
     );
   });
 

--- a/backend/tests/setup.mjs
+++ b/backend/tests/setup.mjs
@@ -9,6 +9,9 @@ import { jest } from '@jest/globals';
 import database from '../src/config/database.ts';
 import { runMigrations } from '../src/scripts/migrate.ts';
 
+// Increase default timeout for all tests to handle DB reconnection
+jest.setTimeout(30000);
+
 // Global test setup
 beforeAll(async () => {
   // Ensure test database exists by running base migrations against the configured DB
@@ -18,7 +21,7 @@ beforeAll(async () => {
     // If DB already exists, proceed
     // Any real errors will surface when running tests
   }
-});
+}, 30000);
 
 afterAll(async () => {
   // Close database connections


### PR DESCRIPTION
This pull request reduces the number of runs for property-based tests across several test suites to improve test performance and execution time. In addition, it includes minor improvements to test data generation and validation logic for sprint properties.

Test performance improvements:

* Reduced the `numRuns` parameter from 100 or 200 to 25 across all property-based tests in `issueProperties.test.ts`, `boardProperties.test.ts`, `notificationProperties.test.ts`, `searchProperties.test.ts`, and `sprintProperties.test.ts` to speed up test execution. [[1]](diffhunk://#diff-a68818f8812fd3d89f1fee19eb94b25a9d805736155919e608c9281c0589d39cL90-R90) [[2]](diffhunk://#diff-a68818f8812fd3d89f1fee19eb94b25a9d805736155919e608c9281c0589d39cL110-R110) [[3]](diffhunk://#diff-a68818f8812fd3d89f1fee19eb94b25a9d805736155919e608c9281c0589d39cL129-R129) [[4]](diffhunk://#diff-a68818f8812fd3d89f1fee19eb94b25a9d805736155919e608c9281c0589d39cL160-R160) [[5]](diffhunk://#diff-a68818f8812fd3d89f1fee19eb94b25a9d805736155919e608c9281c0589d39cL176-R176) [[6]](diffhunk://#diff-a68818f8812fd3d89f1fee19eb94b25a9d805736155919e608c9281c0589d39cL191-R191) [[7]](diffhunk://#diff-47d8d3a216fea8d79eaa6890473171edb39553be8d14888bc09b772df0385b85L64-R63) [[8]](diffhunk://#diff-47d8d3a216fea8d79eaa6890473171edb39553be8d14888bc09b772df0385b85L89-R88) [[9]](diffhunk://#diff-47d8d3a216fea8d79eaa6890473171edb39553be8d14888bc09b772df0385b85L124-R123) [[10]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL183-R183) [[11]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL213-R213) [[12]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL238-R238) [[13]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL262-R262) [[14]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL293-R293) [[15]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL318-R318) [[16]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL329-R329) [[17]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL346-R346) [[18]](diffhunk://#diff-145c565694df21842e9ad9432b5d6b46a3b3fe409b69cc58f51c3e33096d459dL376-R376) [[19]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL221-R221) [[20]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL243-R243) [[21]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL257-R257) [[22]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL274-R274) [[23]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL291-R291) [[24]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL308-R308) [[25]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL347-R347) [[26]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL367-R367) [[27]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL387-R387) [[28]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL407-R407) [[29]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL429-R429) [[30]](diffhunk://#diff-d69bca64e4d47ffbcae6b342d1272e85fb6c28974518ccf7605086404b83e02bL456-R456) [[31]](diffhunk://#diff-42605ec1301589696848ad91c0fab0eecf1f2e90fd97ffdc17b766ef5199a73fR81-R107) [[32]](diffhunk://#diff-42605ec1301589696848ad91c0fab0eecf1f2e90fd97ffdc17b766ef5199a73fL143-R143) [[33]](diffhunk://#diff-42605ec1301589696848ad91c0fab0eecf1f2e90fd97ffdc17b766ef5199a73fL172-R172) [[34]](diffhunk://#diff-42605ec1301589696848ad91c0fab0eecf1f2e90fd97ffdc17b766ef5199a73fL203-R203) [[35]](diffhunk://#diff-42605ec1301589696848ad91c0fab0eecf1f2e90fd97ffdc17b766ef5199a73fL248-R248) [[36]](diffhunk://#diff-42605ec1301589696848ad91c0fab0eecf1f2e90fd97ffdc17b766ef5199a73fL284-R284)

Sprint property test improvements:

* Updated the arbitrary for issue IDs in `sprintProperties.test.ts` to use a regular expression that matches 24-character hexadecimal strings, ensuring ID format correctness.
* Improved date validation in sprint property tests by adding checks for valid dates and simplifying error messages for clarity.

Test code cleanup:

* Removed unused imports from `issueProperties.test.ts` and `sprintProperties.test.ts` for cleaner code. [[1]](diffhunk://#diff-47d8d3a216fea8d79eaa6890473171edb39553be8d14888bc09b772df0385b85L9) [[2]](diffhunk://#diff-42605ec1301589696848ad91c0fab0eecf1f2e90fd97ffdc17b766ef5199a73fL8)