### PR TITLE
Feat/backend/attachments

### DIFF
--- a/backend/src/models/Attachment.ts
+++ b/backend/src/models/Attachment.ts
@@ -1,0 +1,106 @@
+import database from '../config/database.js';
+import { mapDoc, toObjectId, withTimestampsOnCreate } from '../utils/mongo.js';
+
+class Attachment {
+  [key: string]: any;
+
+  constructor(data: any = {}) {
+    this.id = data.id;
+    this.organizationId = data.organizationId || data.organization_id;
+    this.issueId = data.issueId || data.issue_id;
+    this.uploadedBy = data.uploadedBy || data.uploaded_by;
+    this.filename = data.filename;
+    this.originalName = data.originalName || data.original_name;
+    this.mimeType = data.mimeType || data.mime_type;
+    this.sizeBytes = data.sizeBytes !== undefined ? data.sizeBytes : data.size_bytes;
+    this.storagePath = data.storagePath || data.storage_path;
+    this.createdAt = data.createdAt || data.created_at;
+  }
+
+  static async _collection() {
+    return database.getCollection('attachments');
+  }
+
+  static _fromDoc(doc: any): Attachment | null {
+    return doc ? new Attachment(mapDoc(doc)) : null;
+  }
+
+  static async create(attachmentData: any): Promise<Attachment> {
+    try {
+      const attachments = await Attachment._collection();
+
+      const payload = withTimestampsOnCreate({
+        organizationId: attachmentData.organizationId || attachmentData.organization_id || null,
+        issueId: attachmentData.issueId || attachmentData.issue_id,
+        uploadedBy: attachmentData.uploadedBy || attachmentData.uploaded_by,
+        filename: attachmentData.filename,
+        originalName: attachmentData.originalName || attachmentData.original_name,
+        mimeType: attachmentData.mimeType || attachmentData.mime_type,
+        sizeBytes: attachmentData.sizeBytes !== undefined ? attachmentData.sizeBytes : attachmentData.size_bytes,
+        storagePath: attachmentData.storagePath || attachmentData.storage_path,
+      });
+
+      const result = await attachments.insertOne(payload);
+      return await Attachment.findById(result.insertedId.toHexString());
+    } catch (error) {
+      throw new Error(`Error creating attachment: ${error.message}`);
+    }
+  }
+
+  static async findById(id: string): Promise<Attachment | null> {
+    try {
+      const attachments = await Attachment._collection();
+      const _id = toObjectId(id);
+      if (!_id) return null;
+
+      const doc = await attachments.findOne({ _id });
+      return Attachment._fromDoc(doc);
+    } catch (error) {
+      throw new Error(`Error finding attachment by ID: ${error.message}`);
+    }
+  }
+
+  static async findByIssue(issueId: string): Promise<Attachment[]> {
+    try {
+      const attachments = await Attachment._collection();
+      const docs = await attachments.find({ issueId }).sort({ createdAt: 1 }).toArray();
+      return docs.map((doc) => Attachment._fromDoc(doc));
+    } catch (error) {
+      throw new Error(`Error finding attachments by issue: ${error.message}`);
+    }
+  }
+
+  static async delete(id: string): Promise<boolean> {
+    try {
+      const attachments = await Attachment._collection();
+      const _id = toObjectId(id);
+      if (!_id) return false;
+
+      const result = await attachments.deleteOne({ _id });
+      return result.deletedCount > 0;
+    } catch (error) {
+      throw new Error(`Error deleting attachment: ${error.message}`);
+    }
+  }
+
+  toObject(): object {
+    return {
+      id: this.id,
+      organizationId: this.organizationId,
+      issueId: this.issueId,
+      uploadedBy: this.uploadedBy,
+      filename: this.filename,
+      originalName: this.originalName,
+      mimeType: this.mimeType,
+      sizeBytes: this.sizeBytes,
+      storagePath: this.storagePath,
+      createdAt: this.createdAt,
+    };
+  }
+
+  toJSON(): object {
+    return this.toObject();
+  }
+}
+
+export default Attachment;

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -11,6 +11,7 @@ import ActivityLog from './ActivityLog.js';
 import TimeEntry from './TimeEntry.js';
 import ProjectMember from './ProjectMember.js';
 import SavedFilter from './SavedFilter.js';
+import Attachment from './Attachment.js';
 
 // Task is an alias for Issue for backward compatibility
 const Task = Issue;
@@ -26,7 +27,8 @@ export {
   ActivityLog,
   TimeEntry,
   ProjectMember,
-  SavedFilter
+  SavedFilter,
+  Attachment
 };
 
 export default {
@@ -40,5 +42,6 @@ export default {
   ActivityLog,
   TimeEntry,
   ProjectMember,
-  SavedFilter
+  SavedFilter,
+  Attachment
 };

--- a/backend/src/routes/attachmentRoutes.ts
+++ b/backend/src/routes/attachmentRoutes.ts
@@ -1,0 +1,69 @@
+import express from 'express';
+import multer from 'multer';
+import attachmentService from '../services/attachmentService.js';
+import { authenticateToken } from '../middleware/auth.js';
+
+const router = express.Router();
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 25 * 1024 * 1024 },
+});
+
+// POST /api/issues/:id/attachments — upload attachment
+router.post('/issues/:id/attachments', authenticateToken, (req, res, next) => {
+  upload.single('file')(req, res, async (err) => {
+    if (err) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(413).json({ success: false, message: 'File size exceeds the 25 MB limit' });
+      }
+      return next(err);
+    }
+    try {
+      const attachment = await attachmentService.uploadAttachment(
+        req.params.id,
+        req.file,
+        req.user.id
+      );
+      return res.status(201).json({ success: true, data: attachment });
+    } catch (error) {
+      if (error.statusCode) {
+        return res.status(error.statusCode).json({ success: false, message: error.message });
+      }
+      return next(error);
+    }
+  });
+});
+
+// GET /api/issues/:id/attachments/:aid/download — download attachment
+router.get('/issues/:id/attachments/:aid/download', authenticateToken, async (req, res, next) => {
+  try {
+    const { attachment, stream } = await attachmentService.downloadAttachment(
+      req.params.aid,
+      req.user.id
+    );
+    res.setHeader('Content-Type', attachment.mimeType);
+    res.setHeader('Content-Disposition', `attachment; filename="${attachment.originalName}"`);
+    stream.pipe(res);
+  } catch (error) {
+    if (error.statusCode) {
+      return res.status(error.statusCode).json({ success: false, message: error.message });
+    }
+    return next(error);
+  }
+});
+
+// DELETE /api/issues/:id/attachments/:aid — delete attachment
+router.delete('/issues/:id/attachments/:aid', authenticateToken, async (req, res, next) => {
+  try {
+    await attachmentService.deleteAttachment(req.params.aid, req.user.id);
+    return res.status(204).send();
+  } catch (error) {
+    if (error.statusCode) {
+      return res.status(error.statusCode).json({ success: false, message: error.message });
+    }
+    return next(error);
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -27,6 +27,7 @@ import issueRoutes from './routes/issueRoutes.js';
 import boardRoutes from './routes/boardRoutes.js';
 import sprintRoutes from './routes/sprintRoutes.js';
 import filterRoutes from './routes/filterRoutes.js';
+import attachmentRoutes from './routes/attachmentRoutes.js';
 // import aiRoutes from './routes/ai.js';
 
 const app = express();
@@ -101,6 +102,7 @@ app.use('/api/issues', issueRoutes);
 app.use('/api', boardRoutes);
 app.use('/api', sprintRoutes);
 app.use('/api/filters', filterRoutes);
+app.use('/api', attachmentRoutes);
 // app.use('/api/ai', aiRoutes);
 
 // Default route

--- a/backend/src/services/attachmentService.ts
+++ b/backend/src/services/attachmentService.ts
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import Attachment from '../models/Attachment.js';
+import Issue from '../models/Issue.js';
+import ProjectMember from '../models/ProjectMember.js';
+
+const ALLOWED_MIME_TYPES = new Set([
+  'application/pdf',
+  'text/plain',
+  'text/csv',
+  'application/json',
+  'application/zip',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+]);
+
+const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25 MB
+
+const createError = (message: string, statusCode: number) => {
+  const err: any = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+};
+
+const isMimeTypeAllowed = (mimeType: string): boolean => {
+  if (ALLOWED_MIME_TYPES.has(mimeType)) return true;
+  if (mimeType.startsWith('image/')) return true;
+  return false;
+};
+
+const attachmentService = {
+  async uploadAttachment(
+    issueId: string,
+    file: Express.Multer.File,
+    userId: string
+  ): Promise<Attachment> {
+    if (!isMimeTypeAllowed(file.mimetype)) {
+      throw createError(`File type '${file.mimetype}' is not allowed`, 400);
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      throw createError('File size exceeds the 25 MB limit', 413);
+    }
+
+    const uniqueFilename = `${crypto.randomUUID()}-${file.originalname}`;
+    const storagePath = path.join('uploads', uniqueFilename);
+
+    await fs.promises.mkdir('uploads', { recursive: true });
+    await fs.promises.writeFile(storagePath, file.buffer);
+
+    const attachment = await Attachment.create({
+      issueId,
+      uploadedBy: userId,
+      filename: uniqueFilename,
+      originalName: file.originalname,
+      mimeType: file.mimetype,
+      sizeBytes: file.size,
+      storagePath,
+    });
+
+    return attachment;
+  },
+
+  async downloadAttachment(
+    attachmentId: string,
+    userId: string
+  ): Promise<{ attachment: Attachment; stream: fs.ReadStream }> {
+    const attachment = await Attachment.findById(attachmentId);
+    if (!attachment) {
+      throw createError('Attachment not found', 404);
+    }
+
+    const issue = await Issue.findById(attachment.issueId);
+    if (!issue) {
+      throw createError('Issue not found', 404);
+    }
+
+    const member = await ProjectMember.findOne({ projectId: issue.projectId, userId });
+    if (!member) {
+      throw createError('Access denied: not a member of this project', 403);
+    }
+
+    const stream = fs.createReadStream(attachment.storagePath);
+    return { attachment, stream };
+  },
+
+  async deleteAttachment(attachmentId: string, userId: string): Promise<void> {
+    const attachment = await Attachment.findById(attachmentId);
+    if (!attachment) {
+      throw createError('Attachment not found', 404);
+    }
+
+    const issue = await Issue.findById(attachment.issueId);
+    if (!issue) {
+      throw createError('Issue not found', 404);
+    }
+
+    const member = await ProjectMember.findOne({ projectId: issue.projectId, userId });
+    if (!member) {
+      throw createError('Access denied: not a member of this project', 403);
+    }
+
+    try {
+      await fs.promises.unlink(attachment.storagePath);
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+
+    await Attachment.delete(attachmentId);
+  },
+};
+
+export default attachmentService;

--- a/backend/tests/attachments.test.mjs
+++ b/backend/tests/attachments.test.mjs
@@ -1,0 +1,200 @@
+import { describe, test, expect, beforeAll, beforeEach, jest } from '@jest/globals';
+import request from 'supertest';
+import app from '../src/server.ts';
+import database from '../src/config/database.ts';
+import { cleanupUsersByEmails, clearProjectDomainData } from './dbTestUtils.mjs';
+
+jest.setTimeout(30000);
+
+async function registerAndLogin(user) {
+  const reg = await request(app).post('/api/auth/register').send(user).expect(201);
+  const token = reg.body.data.token;
+  const me = await request(app).get('/api/auth/me').set('Authorization', `Bearer ${token}`).expect(200);
+  return { token, user: me.body.data };
+}
+
+describe('Attachments API', () => {
+  let manager, outsider;
+  let projectId, issueId;
+
+  beforeAll(async () => {
+    await cleanupUsersByEmails([
+      'attach-mgr@example.com',
+      'attach-outsider@example.com',
+    ]);
+    manager = await registerAndLogin({
+      email: 'attach-mgr@example.com',
+      password: 'Password123!',
+      firstName: 'AttachMgr',
+      lastName: 'User',
+      role: 'manager',
+    });
+    outsider = await registerAndLogin({
+      email: 'attach-outsider@example.com',
+      password: 'Password123!',
+      firstName: 'Outsider',
+      lastName: 'User',
+      role: 'developer',
+    });
+  });
+
+  beforeEach(async () => {
+    await clearProjectDomainData();
+    const db = await database.connect();
+    await db.collection('issues').deleteMany({});
+    await db.collection('attachments').deleteMany({});
+
+    const projRes = await request(app)
+      .post('/api/projects')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'Attach Test Proj' })
+      .expect(201);
+    projectId = projRes.body.data.id;
+
+    const issueRes = await request(app)
+      .post('/api/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ title: 'Attach Issue', projectId, createdBy: manager.user.id })
+      .expect(201);
+    issueId = issueRes.body.data.id;
+  });
+
+  // Requirements 9.1 — upload stores all required fields
+  test('upload creates attachment record with all required fields', async () => {
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .attach('file', Buffer.from('hello world'), { filename: 'hello.txt', contentType: 'text/plain' })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    const data = res.body.data;
+    expect(data.issueId).toBe(issueId);
+    expect(data.uploadedBy).toBe(manager.user.id);
+    expect(data.originalName).toBe('hello.txt');
+    expect(data.mimeType).toBe('text/plain');
+    expect(data.sizeBytes).toBeGreaterThan(0);
+    expect(data.storagePath).toBeTruthy();
+    expect(data.createdAt).toBeTruthy();
+  });
+
+  // Requirements 9.2, 9.3 — 413 on oversized file
+  test('returns 413 when file exceeds 25 MB', async () => {
+    const oversized = Buffer.alloc(26 * 1024 * 1024, 'x'); // 26 MB
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .attach('file', oversized, { filename: 'big.bin', contentType: 'application/octet-stream' })
+      .expect(413);
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toMatch(/25 MB/i);
+  });
+
+  // Requirements 9.7 — 403 for non-member on download
+  test('returns 403 when non-member tries to download attachment', async () => {
+    // Upload as manager first
+    const uploadRes = await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .attach('file', Buffer.from('secret'), { filename: 'secret.txt', contentType: 'text/plain' })
+      .expect(201);
+    const attachmentId = uploadRes.body.data.id;
+
+    // Outsider (not a project member) tries to download
+    const res = await request(app)
+      .get(`/api/issues/${issueId}/attachments/${attachmentId}/download`)
+      .set('Authorization', `Bearer ${outsider.token}`)
+      .expect(403);
+
+    expect(res.body.success).toBe(false);
+  });
+
+  // Requirements 9.7 — 403 for non-member on delete
+  test('returns 403 when non-member tries to delete attachment', async () => {
+    const uploadRes = await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .attach('file', Buffer.from('data'), { filename: 'data.txt', contentType: 'text/plain' })
+      .expect(201);
+    const attachmentId = uploadRes.body.data.id;
+
+    const res = await request(app)
+      .delete(`/api/issues/${issueId}/attachments/${attachmentId}`)
+      .set('Authorization', `Bearer ${outsider.token}`)
+      .expect(403);
+
+    expect(res.body.success).toBe(false);
+  });
+
+  // Requirements 9.4 — download returns correct Content-Type and Content-Disposition headers
+  test('download returns correct Content-Type and Content-Disposition headers', async () => {
+    const content = 'attachment content';
+    const uploadRes = await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .attach('file', Buffer.from(content), { filename: 'report.txt', contentType: 'text/plain' })
+      .expect(201);
+    const attachmentId = uploadRes.body.data.id;
+
+    const res = await request(app)
+      .get(`/api/issues/${issueId}/attachments/${attachmentId}/download`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(200);
+
+    expect(res.headers['content-type']).toMatch(/text\/plain/);
+    expect(res.headers['content-disposition']).toMatch(/attachment/);
+    expect(res.headers['content-disposition']).toMatch(/report\.txt/);
+  });
+
+  // Requirements 9.5 — delete removes record and file
+  test('delete removes attachment record and subsequent download returns 404', async () => {
+    const uploadRes = await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .attach('file', Buffer.from('to delete'), { filename: 'todelete.txt', contentType: 'text/plain' })
+      .expect(201);
+    const attachmentId = uploadRes.body.data.id;
+
+    // Delete
+    await request(app)
+      .delete(`/api/issues/${issueId}/attachments/${attachmentId}`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(204);
+
+    // Subsequent download should 404
+    await request(app)
+      .get(`/api/issues/${issueId}/attachments/${attachmentId}/download`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(404);
+  });
+
+  // Requirements 9.6 — allowed MIME types accepted
+  test('accepts image MIME type upload', async () => {
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .attach('file', Buffer.from('fake-png'), { filename: 'screenshot.png', contentType: 'image/png' })
+      .expect(201);
+
+    expect(res.body.data.mimeType).toBe('image/png');
+  });
+
+  test('accepts PDF upload', async () => {
+    const res = await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .attach('file', Buffer.from('%PDF-fake'), { filename: 'doc.pdf', contentType: 'application/pdf' })
+      .expect(201);
+
+    expect(res.body.data.mimeType).toBe('application/pdf');
+  });
+
+  // Unauthenticated request
+  test('returns 401 for unauthenticated upload', async () => {
+    await request(app)
+      .post(`/api/issues/${issueId}/attachments`)
+      .attach('file', Buffer.from('data'), { filename: 'file.txt', contentType: 'text/plain' })
+      .expect(401);
+  });
+});

--- a/backend/tests/properties/attachmentProperties.test.ts
+++ b/backend/tests/properties/attachmentProperties.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Property-based tests for Attachment record completeness and download headers.
+ * Feature: jira-level-platform
+ * Validates: Requirements 9.1, 9.4
+ */
+
+import * as fc from 'fast-check';
+import Attachment from '../../src/models/Attachment.js';
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors the header-generation logic used in the download route:
+ * sets Content-Type to the attachment's mimeType and
+ * Content-Disposition to `attachment; filename="<originalName>"`.
+ */
+function buildDownloadHeaders(attachment: {
+  mimeType: string;
+  originalName: string;
+}): { 'Content-Type': string; 'Content-Disposition': string } {
+  return {
+    'Content-Type': attachment.mimeType,
+    'Content-Disposition': `attachment; filename="${attachment.originalName}"`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+const hexIdArb = fc.stringMatching(/^[a-f0-9]{24}$/);
+
+const mimeTypeArb = fc.oneof(
+  fc.constant('application/pdf'),
+  fc.constant('text/plain'),
+  fc.constant('text/csv'),
+  fc.constant('application/json'),
+  fc.constant('application/zip'),
+  fc.constant('image/png'),
+  fc.constant('image/jpeg'),
+  fc.constant('image/gif'),
+  fc.constant('application/msword'),
+  fc.constant('application/vnd.openxmlformats-officedocument.wordprocessingml.document'),
+);
+
+// Safe filename characters (no null bytes or path separators)
+const safeFilenameArb = fc
+  .string({ minLength: 1, maxLength: 64 })
+  .filter((s) => !s.includes('\0') && !s.includes('/') && !s.includes('\\'));
+
+const attachmentDataArb = fc.record({
+  issueId: hexIdArb,
+  uploadedBy: hexIdArb,
+  organizationId: hexIdArb,
+  filename: safeFilenameArb,
+  originalName: safeFilenameArb,
+  mimeType: mimeTypeArb,
+  sizeBytes: fc.integer({ min: 1, max: 25 * 1024 * 1024 }),
+  storagePath: safeFilenameArb.map((n) => `uploads/${n}`),
+});
+
+// ---------------------------------------------------------------------------
+// Property 15: Attachment record completeness
+// Feature: jira-level-platform, Property 15: Attachment record completeness
+// ---------------------------------------------------------------------------
+
+describe('Property 15: Attachment record completeness', () => {
+  // **Validates: Requirements 9.1**
+
+  it('an Attachment constructed from valid upload data contains all required fields with correct types', () => {
+    // Feature: jira-level-platform, Property 15: Attachment record completeness
+    fc.assert(
+      fc.property(attachmentDataArb, (data) => {
+        const attachment = new Attachment({
+          ...data,
+          createdAt: new Date(),
+        });
+
+        // All required fields must be present (not undefined / null)
+        expect(attachment.issueId).toBeDefined();
+        expect(attachment.uploadedBy).toBeDefined();
+        expect(attachment.filename).toBeDefined();
+        expect(attachment.originalName).toBeDefined();
+        expect(attachment.mimeType).toBeDefined();
+        expect(attachment.sizeBytes).toBeDefined();
+        expect(attachment.storagePath).toBeDefined();
+        expect(attachment.createdAt).toBeDefined();
+
+        // Type assertions
+        expect(typeof attachment.issueId).toBe('string');
+        expect(typeof attachment.uploadedBy).toBe('string');
+        expect(typeof attachment.filename).toBe('string');
+        expect(typeof attachment.originalName).toBe('string');
+        expect(typeof attachment.mimeType).toBe('string');
+        expect(typeof attachment.sizeBytes).toBe('number');
+        expect(typeof attachment.storagePath).toBe('string');
+
+        // Values must match what was supplied
+        expect(attachment.issueId).toBe(data.issueId);
+        expect(attachment.uploadedBy).toBe(data.uploadedBy);
+        expect(attachment.filename).toBe(data.filename);
+        expect(attachment.originalName).toBe(data.originalName);
+        expect(attachment.mimeType).toBe(data.mimeType);
+        expect(attachment.sizeBytes).toBe(data.sizeBytes);
+        expect(attachment.storagePath).toBe(data.storagePath);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it('toObject() serialization preserves all required fields', () => {
+    // Feature: jira-level-platform, Property 15: Attachment record completeness
+    fc.assert(
+      fc.property(attachmentDataArb, (data) => {
+        const createdAt = new Date();
+        const attachment = new Attachment({ ...data, createdAt });
+        const obj = attachment.toObject() as any;
+
+        expect(obj.issueId).toBe(data.issueId);
+        expect(obj.uploadedBy).toBe(data.uploadedBy);
+        expect(obj.filename).toBe(data.filename);
+        expect(obj.originalName).toBe(data.originalName);
+        expect(obj.mimeType).toBe(data.mimeType);
+        expect(obj.sizeBytes).toBe(data.sizeBytes);
+        expect(obj.storagePath).toBe(data.storagePath);
+        expect(obj.createdAt).toBe(createdAt);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property 16: Attachment download headers
+// Feature: jira-level-platform, Property 16: Attachment download headers
+// ---------------------------------------------------------------------------
+
+describe('Property 16: Attachment download headers', () => {
+  // **Validates: Requirements 9.4**
+
+  it('Content-Type header matches the attachment mimeType', () => {
+    // Feature: jira-level-platform, Property 16: Attachment download headers
+    fc.assert(
+      fc.property(attachmentDataArb, (data) => {
+        const attachment = new Attachment({ ...data, createdAt: new Date() });
+        const headers = buildDownloadHeaders({
+          mimeType: attachment.mimeType,
+          originalName: attachment.originalName,
+        });
+
+        expect(headers['Content-Type']).toBe(attachment.mimeType);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it('Content-Disposition header contains the originalName', () => {
+    // Feature: jira-level-platform, Property 16: Attachment download headers
+    fc.assert(
+      fc.property(attachmentDataArb, (data) => {
+        const attachment = new Attachment({ ...data, createdAt: new Date() });
+        const headers = buildDownloadHeaders({
+          mimeType: attachment.mimeType,
+          originalName: attachment.originalName,
+        });
+
+        expect(headers['Content-Disposition']).toContain(attachment.originalName);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it('Content-Disposition header uses the "attachment" disposition type', () => {
+    // Feature: jira-level-platform, Property 16: Attachment download headers
+    fc.assert(
+      fc.property(attachmentDataArb, (data) => {
+        const attachment = new Attachment({ ...data, createdAt: new Date() });
+        const headers = buildDownloadHeaders({
+          mimeType: attachment.mimeType,
+          originalName: attachment.originalName,
+        });
+
+        expect(headers['Content-Disposition']).toMatch(/^attachment;/);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/backend/tests/properties/filterProperties.test.ts
+++ b/backend/tests/properties/filterProperties.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Property-based tests for SavedFilter criteria round-trip.
+ * Feature: jira-level-platform
+ * Validates: Requirements 8.5
+ */
+
+import * as fc from 'fast-check';
+
+// ---------------------------------------------------------------------------
+// Types (mirrors SavedFilter.FilterCriteria and SearchService logic)
+// ---------------------------------------------------------------------------
+
+interface FilterCriteria {
+  query?: string;
+  issueType?: string;
+  status?: string;
+  priority?: string;
+  assigneeId?: string;
+  projectId?: string;
+  sprintId?: string;
+  label?: string[];
+  componentId?: string;
+  bugSeverity?: string;
+  versionId?: string;
+  epicId?: string;
+  storyPointsMin?: number;
+  storyPointsMax?: number;
+  createdAtFrom?: string;
+  createdAtTo?: string;
+  updatedAtFrom?: string;
+  updatedAtTo?: string;
+  dueDateFrom?: string;
+  dueDateTo?: string;
+}
+
+interface Issue {
+  id: string;
+  projectId: string;
+  issueType: 'task' | 'bug' | 'epic';
+  title: string;
+  description?: string;
+  status: string;
+  priority: 'low' | 'medium' | 'high' | 'critical';
+  assignedTo?: string;
+  sprintId?: string;
+  componentId?: string;
+  versionId?: string;
+  epicId?: string;
+  storyPoints?: number;
+  bugSeverity?: 'critical' | 'high' | 'medium' | 'low';
+  labels?: string[];
+  dueDate?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Pure in-memory filter — mirrors SearchService.searchIssues AND logic
+// ---------------------------------------------------------------------------
+
+function applyFilters(issues: Issue[], criteria: FilterCriteria): Issue[] {
+  return issues.filter((issue) => {
+    if (criteria.query && criteria.query.trim().length > 0) {
+      const q = criteria.query.trim().toLowerCase();
+      const inTitle = issue.title.toLowerCase().includes(q);
+      const inDesc = issue.description ? issue.description.toLowerCase().includes(q) : false;
+      if (!inTitle && !inDesc) return false;
+    }
+    if (criteria.issueType && issue.issueType !== criteria.issueType) return false;
+    if (criteria.status && issue.status !== criteria.status) return false;
+    if (criteria.priority && issue.priority !== criteria.priority) return false;
+    if (criteria.assigneeId && issue.assignedTo !== criteria.assigneeId) return false;
+    if (criteria.projectId && issue.projectId !== criteria.projectId) return false;
+    if (criteria.sprintId && issue.sprintId !== criteria.sprintId) return false;
+    if (criteria.componentId && issue.componentId !== criteria.componentId) return false;
+    if (criteria.bugSeverity && issue.bugSeverity !== criteria.bugSeverity) return false;
+    if (criteria.versionId && issue.versionId !== criteria.versionId) return false;
+    if (criteria.epicId && issue.epicId !== criteria.epicId) return false;
+    if (criteria.label && criteria.label.length > 0) {
+      const issueLabels = issue.labels ?? [];
+      if (!criteria.label.every((l) => issueLabels.includes(l))) return false;
+    }
+    if (criteria.storyPointsMin != null) {
+      if (issue.storyPoints == null || issue.storyPoints < criteria.storyPointsMin) return false;
+    }
+    if (criteria.storyPointsMax != null) {
+      if (issue.storyPoints == null || issue.storyPoints > criteria.storyPointsMax) return false;
+    }
+    if (criteria.createdAtFrom && issue.createdAt < new Date(criteria.createdAtFrom)) return false;
+    if (criteria.createdAtTo && issue.createdAt > new Date(criteria.createdAtTo)) return false;
+    if (criteria.updatedAtFrom && issue.updatedAt < new Date(criteria.updatedAtFrom)) return false;
+    if (criteria.updatedAtTo && issue.updatedAt > new Date(criteria.updatedAtTo)) return false;
+    if (criteria.dueDateFrom && (!issue.dueDate || issue.dueDate < new Date(criteria.dueDateFrom))) return false;
+    if (criteria.dueDateTo && (!issue.dueDate || issue.dueDate > new Date(criteria.dueDateTo))) return false;
+    return true;
+  });
+}
+
+/**
+ * Serializes a FilterCriteria to JSON and back, as SavedFilter.criteria is
+ * stored and retrieved via MongoDB (BSON → JSON round-trip).
+ */
+function roundTripCriteria(criteria: FilterCriteria): FilterCriteria {
+  return JSON.parse(JSON.stringify(criteria));
+}
+
+/**
+ * Returns the sorted list of issue IDs from a result set.
+ */
+function resultIds(issues: Issue[]): string[] {
+  return issues.map((i) => i.id).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+const issueTypeArb = fc.constantFrom<'task' | 'bug' | 'epic'>('task', 'bug', 'epic');
+const priorityArb = fc.constantFrom<'low' | 'medium' | 'high' | 'critical'>('low', 'medium', 'high', 'critical');
+const bugSeverityArb = fc.constantFrom<'critical' | 'high' | 'medium' | 'low'>('critical', 'high', 'medium', 'low');
+const statusArb = fc.constantFrom('To Do', 'In Progress', 'In Review', 'Done');
+const idArb = fc.stringMatching(/^[a-f0-9]{8,12}$/);
+const labelArb = fc.stringMatching(/^[a-z][a-z0-9-]{0,10}$/);
+const isoDateArb = fc
+  .date({ min: new Date('2023-01-01'), max: new Date('2025-12-31') })
+  .filter((d) => !isNaN(d.getTime()))
+  .map((d) => d.toISOString());
+
+const arbitraryIssue = (): fc.Arbitrary<Issue> =>
+  fc.record({
+    id: idArb,
+    projectId: idArb,
+    issueType: issueTypeArb,
+    title: fc.string({ minLength: 1, maxLength: 60 }),
+    description: fc.option(fc.string({ minLength: 0, maxLength: 100 }), { nil: undefined }),
+    status: statusArb,
+    priority: priorityArb,
+    assignedTo: fc.option(idArb, { nil: undefined }),
+    sprintId: fc.option(idArb, { nil: undefined }),
+    componentId: fc.option(idArb, { nil: undefined }),
+    versionId: fc.option(idArb, { nil: undefined }),
+    epicId: fc.option(idArb, { nil: undefined }),
+    storyPoints: fc.option(fc.nat({ max: 50 }), { nil: undefined }),
+    bugSeverity: fc.option(bugSeverityArb, { nil: undefined }),
+    labels: fc.option(fc.array(labelArb, { maxLength: 4 }), { nil: undefined }),
+    dueDate: fc.option(fc.date({ min: new Date('2023-01-01'), max: new Date('2025-12-31') }), { nil: undefined }),
+    createdAt: fc.date({ min: new Date('2023-01-01'), max: new Date('2025-12-31') }),
+    updatedAt: fc.date({ min: new Date('2023-01-01'), max: new Date('2025-12-31') }),
+  });
+
+/**
+ * Generates a FilterCriteria with all fields optional.
+ * Date range fields are generated as ISO strings to survive JSON round-trip.
+ */
+const arbitraryFilterCriteria = (): fc.Arbitrary<FilterCriteria> =>
+  fc.record(
+    {
+      query: fc.option(fc.string({ minLength: 1, maxLength: 15 }), { nil: undefined }),
+      issueType: fc.option(issueTypeArb, { nil: undefined }),
+      status: fc.option(statusArb, { nil: undefined }),
+      priority: fc.option(priorityArb, { nil: undefined }),
+      assigneeId: fc.option(idArb, { nil: undefined }),
+      projectId: fc.option(idArb, { nil: undefined }),
+      sprintId: fc.option(idArb, { nil: undefined }),
+      label: fc.option(fc.array(labelArb, { minLength: 1, maxLength: 2 }), { nil: undefined }),
+      componentId: fc.option(idArb, { nil: undefined }),
+      bugSeverity: fc.option(bugSeverityArb, { nil: undefined }),
+      versionId: fc.option(idArb, { nil: undefined }),
+      epicId: fc.option(idArb, { nil: undefined }),
+      storyPointsMin: fc.option(fc.nat({ max: 20 }), { nil: undefined }),
+      storyPointsMax: fc.option(fc.integer({ min: 21, max: 50 }), { nil: undefined }),
+      createdAtFrom: fc.option(isoDateArb, { nil: undefined }),
+      createdAtTo: fc.option(isoDateArb, { nil: undefined }),
+      updatedAtFrom: fc.option(isoDateArb, { nil: undefined }),
+      updatedAtTo: fc.option(isoDateArb, { nil: undefined }),
+      dueDateFrom: fc.option(isoDateArb, { nil: undefined }),
+      dueDateTo: fc.option(isoDateArb, { nil: undefined }),
+    },
+    { requiredKeys: [] },
+  );
+
+// ---------------------------------------------------------------------------
+// Property 14: Saved filter criteria round-trip
+// Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+// ---------------------------------------------------------------------------
+
+describe('Property 14: Saved filter criteria round-trip', () => {
+  // **Validates: Requirements 8.5**
+
+  it('JSON round-trip of FilterCriteria preserves all field values', () => {
+    // Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+    fc.assert(
+      fc.property(arbitraryFilterCriteria(), (criteria) => {
+        const restored = roundTripCriteria(criteria);
+
+        // Every key present in the original must survive with the same value
+        for (const key of Object.keys(criteria) as (keyof FilterCriteria)[]) {
+          const original = criteria[key];
+          const after = restored[key];
+
+          if (Array.isArray(original)) {
+            expect(after).toEqual(original);
+          } else {
+            expect(after).toBe(original);
+          }
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it('executing criteria before and after JSON round-trip returns the same issue IDs', () => {
+    // Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+    fc.assert(
+      fc.property(
+        fc.array(arbitraryIssue(), { minLength: 0, maxLength: 40 }),
+        arbitraryFilterCriteria(),
+        (issues, criteria) => {
+          const beforeRoundTrip = applyFilters(issues, criteria);
+          const afterRoundTrip = applyFilters(issues, roundTripCriteria(criteria));
+
+          expect(resultIds(afterRoundTrip)).toEqual(resultIds(beforeRoundTrip));
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('round-tripped criteria produces identical results for every individual issue', () => {
+    // Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+    fc.assert(
+      fc.property(
+        fc.array(arbitraryIssue(), { minLength: 1, maxLength: 30 }),
+        arbitraryFilterCriteria(),
+        (issues, criteria) => {
+          const restored = roundTripCriteria(criteria);
+
+          for (const issue of issues) {
+            const matchesBefore = applyFilters([issue], criteria).length === 1;
+            const matchesAfter = applyFilters([issue], restored).length === 1;
+            expect(matchesAfter).toBe(matchesBefore);
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('empty criteria survives round-trip and still returns all issues', () => {
+    // Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+    fc.assert(
+      fc.property(
+        fc.array(arbitraryIssue(), { minLength: 0, maxLength: 30 }),
+        (issues) => {
+          const empty: FilterCriteria = {};
+          const restored = roundTripCriteria(empty);
+
+          expect(applyFilters(issues, restored).length).toBe(issues.length);
+        },
+      ),
+      { numRuns: 50 },
+    );
+  });
+
+  it('single-field criteria survives round-trip with correct filtering', () => {
+    // Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+    fc.assert(
+      fc.property(
+        fc.array(arbitraryIssue(), { minLength: 0, maxLength: 40 }),
+        issueTypeArb,
+        (issues, issueType) => {
+          const criteria: FilterCriteria = { issueType };
+          const restored = roundTripCriteria(criteria);
+
+          expect(restored.issueType).toBe(issueType);
+          expect(resultIds(applyFilters(issues, restored))).toEqual(
+            resultIds(applyFilters(issues, criteria)),
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('label array survives round-trip and filters correctly', () => {
+    // Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+    fc.assert(
+      fc.property(
+        fc.array(arbitraryIssue(), { minLength: 0, maxLength: 40 }),
+        fc.array(labelArb, { minLength: 1, maxLength: 3 }),
+        (issues, label) => {
+          const criteria: FilterCriteria = { label };
+          const restored = roundTripCriteria(criteria);
+
+          expect(restored.label).toEqual(label);
+          expect(resultIds(applyFilters(issues, restored))).toEqual(
+            resultIds(applyFilters(issues, criteria)),
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('numeric range fields survive round-trip without type coercion', () => {
+    // Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+    fc.assert(
+      fc.property(
+        fc.nat({ max: 20 }),
+        fc.integer({ min: 21, max: 50 }),
+        (storyPointsMin, storyPointsMax) => {
+          const criteria: FilterCriteria = { storyPointsMin, storyPointsMax };
+          const restored = roundTripCriteria(criteria);
+
+          expect(typeof restored.storyPointsMin).toBe('number');
+          expect(typeof restored.storyPointsMax).toBe('number');
+          expect(restored.storyPointsMin).toBe(storyPointsMin);
+          expect(restored.storyPointsMax).toBe(storyPointsMax);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('ISO date string fields survive round-trip unchanged', () => {
+    // Feature: jira-level-platform, Property 14: Saved filter criteria round-trip
+    fc.assert(
+      fc.property(isoDateArb, isoDateArb, (createdAtFrom, createdAtTo) => {
+        const criteria: FilterCriteria = { createdAtFrom, createdAtTo };
+        const restored = roundTripCriteria(criteria);
+
+        expect(restored.createdAtFrom).toBe(createdAtFrom);
+        expect(restored.createdAtTo).toBe(createdAtTo);
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/backend/tests/search.test.mjs
+++ b/backend/tests/search.test.mjs
@@ -1,10 +1,12 @@
-import { describe, test, expect, beforeAll, beforeEach } from '@jest/globals';
+import { describe, test, expect, beforeAll, beforeEach, jest } from '@jest/globals';
 import request from 'supertest';
 import app from '../src/server.ts';
-import { cleanupUserByEmail, cleanupUsersByEmails, clearProjectDomainData } from './dbTestUtils.mjs';
+import database from '../src/config/database.ts';
+import { cleanupUsersByEmails, clearProjectDomainData } from './dbTestUtils.mjs';
+
+jest.setTimeout(30000);
 
 async function registerAndLogin(user) {
-  await cleanupUserByEmail(user.email);
   const reg = await request(app).post('/api/auth/register').send(user).expect(201);
   const token = reg.body.data.token;
   const me = await request(app).get('/api/auth/me').set('Authorization', `Bearer ${token}`).expect(200);
@@ -22,6 +24,9 @@ describe('Search API', () => {
 
   beforeEach(async () => {
     await clearProjectDomainData();
+    const db = await database.connect();
+    await db.collection('issues').deleteMany({});
+    await db.collection('filters').deleteMany({});
 
     const createProj = await request(app)
       .post('/api/projects')
@@ -72,3 +77,387 @@ describe('Search API', () => {
   });
 });
 
+// ─── Advanced Issue Search (Req 8.1) ────────────────────────────────────────
+
+describe('Advanced Issue Search', () => {
+  let manager, projectId, bugId, epicId;
+
+  beforeAll(async () => {
+    await cleanupUsersByEmails(['mgr-advsearch@example.com']);
+    manager = await registerAndLogin({ email: 'mgr-advsearch@example.com', password: 'Password123!', firstName: 'MgrAdv', lastName: 'User', role: 'manager' });
+  });
+
+  beforeEach(async () => {
+    await clearProjectDomainData();
+    const db = await database.connect();
+    await db.collection('issues').deleteMany({});
+
+    const proj = await request(app)
+      .post('/api/projects')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'Adv Search Proj' })
+      .expect(201);
+    projectId = proj.body.data.id;
+
+    const bug = await request(app)
+      .post('/api/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ title: 'Critical Login Bug', projectId, issueType: 'bug', bugSeverity: 'critical', priority: 'high', labels: ['auth', 'login'], storyPoints: 3 })
+      .expect(201);
+    bugId = bug.body.data.id;
+
+    const epic = await request(app)
+      .post('/api/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ title: 'Auth Epic', projectId, issueType: 'epic', priority: 'medium', storyPoints: 13 })
+      .expect(201);
+    epicId = epic.body.data.id;
+
+    // A plain task
+    await request(app)
+      .post('/api/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ title: 'Simple Task', projectId, issueType: 'task', priority: 'low', storyPoints: 1 })
+      .expect(201);
+  });
+
+  test('filters by issueType=bug returns only bugs', async () => {
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ issueType: 'bug', projectId })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    const issues = res.body.data.issues;
+    expect(issues.length).toBeGreaterThan(0);
+    issues.forEach((i) => expect(i.issueType).toBe('bug'));
+  });
+
+  test('filters by bugSeverity=critical returns only critical bugs', async () => {
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ bugSeverity: 'critical', projectId })
+      .expect(200);
+
+    const issues = res.body.data.issues;
+    expect(issues.length).toBeGreaterThan(0);
+    issues.forEach((i) => expect(i.bugSeverity).toBe('critical'));
+  });
+
+  test('filters by storyPointsMin and storyPointsMax', async () => {
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ storyPointsMin: 2, storyPointsMax: 5, projectId })
+      .expect(200);
+
+    const issues = res.body.data.issues;
+    expect(issues.length).toBeGreaterThan(0);
+    issues.forEach((i) => {
+      expect(i.storyPoints).toBeGreaterThanOrEqual(2);
+      expect(i.storyPoints).toBeLessThanOrEqual(5);
+    });
+  });
+
+  test('filters by label returns only issues with that label', async () => {
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ label: 'auth', projectId })
+      .expect(200);
+
+    const issues = res.body.data.issues;
+    expect(issues.length).toBeGreaterThan(0);
+    issues.forEach((i) => expect(i.labels).toContain('auth'));
+  });
+
+  test('filters by epicId returns only child issues of that epic', async () => {
+    // Create a task linked to the epic
+    await request(app)
+      .post('/api/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ title: 'Epic Child Task', projectId, issueType: 'task', epicId })
+      .expect(201);
+
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ epicId, projectId })
+      .expect(200);
+
+    const issues = res.body.data.issues;
+    expect(issues.length).toBeGreaterThan(0);
+    issues.forEach((i) => expect(i.epicId).toBe(epicId));
+  });
+
+  test('filters by createdAt date range', async () => {
+    const from = new Date(Date.now() - 60000).toISOString();
+    const to = new Date(Date.now() + 60000).toISOString();
+
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ createdAtFrom: from, createdAtTo: to, projectId })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.issues.length).toBeGreaterThan(0);
+  });
+
+  test('returns empty array when no issues match criteria (Req 5.7)', async () => {
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ issueType: 'bug', bugSeverity: 'low', projectId })
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.issues).toEqual([]);
+  });
+
+  test('pagination: default page size is 25, max is 100', async () => {
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ projectId })
+      .expect(200);
+
+    expect(res.body.data.pagination).toBeDefined();
+    expect(res.body.data.pagination.itemsPerPage).toBeLessThanOrEqual(25);
+
+    const resMax = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ projectId, limit: 200 })
+      .expect(200);
+
+    expect(resMax.body.data.pagination.itemsPerPage).toBeLessThanOrEqual(100);
+  });
+
+  test('multiple filters apply AND logic (Req 5.3)', async () => {
+    const res = await request(app)
+      .get('/api/search/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .query({ issueType: 'bug', priority: 'high', projectId })
+      .expect(200);
+
+    const issues = res.body.data.issues;
+    issues.forEach((i) => {
+      expect(i.issueType).toBe('bug');
+      expect(i.priority).toBe('high');
+    });
+  });
+});
+
+// ─── Saved Filter CRUD (Req 8.2–8.4, 8.7) ───────────────────────────────────
+
+describe('Saved Filters CRUD', () => {
+  let manager, outsider, projectId, filterId;
+
+  beforeAll(async () => {
+    await cleanupUsersByEmails(['mgr-filter@example.com', 'outsider-filter@example.com']);
+    manager = await registerAndLogin({ email: 'mgr-filter@example.com', password: 'Password123!', firstName: 'MgrF', lastName: 'User', role: 'manager' });
+    outsider = await registerAndLogin({ email: 'outsider-filter@example.com', password: 'Password123!', firstName: 'Out', lastName: 'User', role: 'developer' });
+  });
+
+  beforeEach(async () => {
+    await clearProjectDomainData();
+    const db = await database.connect();
+    await db.collection('issues').deleteMany({});
+    await db.collection('filters').deleteMany({});
+
+    const proj = await request(app)
+      .post('/api/projects')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'Filter Test Proj' })
+      .expect(201);
+    projectId = proj.body.data.id;
+  });
+
+  test('POST /api/filters creates a saved filter (Req 8.2)', async () => {
+    const res = await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'My Bugs', criteria: { issueType: 'bug', projectId } })
+      .expect(201);
+
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.name).toBe('My Bugs');
+    expect(res.body.data.criteria.issueType).toBe('bug');
+    filterId = res.body.data.id;
+  });
+
+  test('POST /api/filters returns 400 when name or criteria missing', async () => {
+    await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'No Criteria' })
+      .expect(400);
+
+    await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ criteria: { issueType: 'bug' } })
+      .expect(400);
+  });
+
+  test('GET /api/filters returns only the authenticated user\'s filters (Req 8.4)', async () => {
+    // Manager creates a filter
+    await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'Manager Filter', criteria: { issueType: 'task' } })
+      .expect(201);
+
+    // Outsider creates a filter
+    await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${outsider.token}`)
+      .send({ name: 'Outsider Filter', criteria: { issueType: 'epic' } })
+      .expect(201);
+
+    const res = await request(app)
+      .get('/api/filters')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+    const names = res.body.data.map((f) => f.name);
+    expect(names).toContain('Manager Filter');
+    expect(names).not.toContain('Outsider Filter');
+  });
+
+  test('GET /api/filters/:id/run executes saved filter criteria (Req 8.3)', async () => {
+    // Create an issue to match
+    await request(app)
+      .post('/api/issues')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ title: 'Bug to find', projectId, issueType: 'bug' })
+      .expect(201);
+
+    const createRes = await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'Bug Filter', criteria: { issueType: 'bug', projectId } })
+      .expect(201);
+    filterId = createRes.body.data.id;
+
+    const runRes = await request(app)
+      .get(`/api/filters/${filterId}/run`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(200);
+
+    expect(runRes.body.success).toBe(true);
+    expect(runRes.body.data.issues).toBeDefined();
+    runRes.body.data.issues.forEach((i) => expect(i.issueType).toBe('bug'));
+  });
+
+  test('DELETE /api/filters/:id returns 204 and removes the filter (Req 8.7)', async () => {
+    const createRes = await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'To Delete', criteria: { issueType: 'task' } })
+      .expect(201);
+    const id = createRes.body.data.id;
+
+    await request(app)
+      .delete(`/api/filters/${id}`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(204);
+
+    // Confirm it's gone from the list
+    const listRes = await request(app)
+      .get('/api/filters')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(200);
+
+    const ids = listRes.body.data.map((f) => f.id);
+    expect(ids).not.toContain(id);
+  });
+
+  test('DELETE /api/filters/:id returns 404 for non-existent filter', async () => {
+    await request(app)
+      .delete('/api/filters/000000000000000000000000')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(404);
+  });
+});
+
+// ─── 403 on inaccessible project filter (Req 8.6) ───────────────────────────
+
+describe('Saved Filter access control', () => {
+  let owner, nonMember, memberProject, nonMemberProject, filterId;
+
+  beforeAll(async () => {
+    await cleanupUsersByEmails(['filter-owner@example.com', 'filter-nonmember@example.com']);
+    owner = await registerAndLogin({ email: 'filter-owner@example.com', password: 'Password123!', firstName: 'Owner', lastName: 'User', role: 'manager' });
+    nonMember = await registerAndLogin({ email: 'filter-nonmember@example.com', password: 'Password123!', firstName: 'NonMember', lastName: 'User', role: 'developer' });
+  });
+
+  beforeEach(async () => {
+    await clearProjectDomainData();
+    const db = await database.connect();
+    await db.collection('issues').deleteMany({});
+    await db.collection('filters').deleteMany({});
+
+    // Project that owner belongs to but nonMember does not
+    const proj = await request(app)
+      .post('/api/projects')
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ name: 'Owner Only Project' })
+      .expect(201);
+    memberProject = proj.body.data.id;
+
+    // nonMember saves a filter pointing at a project they don't belong to
+    const filterRes = await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${nonMember.token}`)
+      .send({ name: 'Restricted Filter', criteria: { issueType: 'bug', projectId: memberProject } })
+      .expect(201);
+    filterId = filterRes.body.data.id;
+  });
+
+  test('running a filter scoped to an inaccessible project returns 403 (Req 8.6)', async () => {
+    const res = await request(app)
+      .get(`/api/filters/${filterId}/run`)
+      .set('Authorization', `Bearer ${nonMember.token}`)
+      .expect(403);
+
+    expect(res.body.success).toBe(false);
+  });
+
+  test('running another user\'s filter returns 403', async () => {
+    // owner creates a filter
+    const ownerFilter = await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ name: 'Owner Filter', criteria: { issueType: 'task' } })
+      .expect(201);
+
+    // nonMember tries to run it
+    await request(app)
+      .get(`/api/filters/${ownerFilter.body.data.id}/run`)
+      .set('Authorization', `Bearer ${nonMember.token}`)
+      .expect(403);
+  });
+
+  test('deleting another user\'s filter returns 403', async () => {
+    const ownerFilter = await request(app)
+      .post('/api/filters')
+      .set('Authorization', `Bearer ${owner.token}`)
+      .send({ name: 'Owner Filter 2', criteria: { issueType: 'task' } })
+      .expect(201);
+
+    await request(app)
+      .delete(`/api/filters/${ownerFilter.body.data.id}`)
+      .set('Authorization', `Bearer ${nonMember.token}`)
+      .expect(403);
+  });
+
+  test('unauthenticated request to filters returns 401', async () => {
+    await request(app).get('/api/filters').expect(401);
+    await request(app).post('/api/filters').send({ name: 'x', criteria: {} }).expect(401);
+  });
+});


### PR DESCRIPTION
This pull request introduces full support for file attachments on issues in the backend. It adds a new `Attachment` model, implements service logic for uploading, downloading, and deleting attachments with proper access control and file validation, and exposes new API endpoints for these operations. Comprehensive tests have also been added to ensure correct behavior and permissions.

**Attachment Model and Service Implementation**
- Added a new `Attachment` model for storing attachment metadata, including fields for file name, MIME type, storage path, and uploader. Methods for creating, finding, and deleting attachments were implemented.
- Implemented `attachmentService` to handle file validation (MIME type and size), storage on disk, and access control (only project members can download/delete).

**API Endpoints**
- Introduced new routes for uploading (`POST /api/issues/:id/attachments`), downloading (`GET /api/issues/:id/attachments/:aid/download`), and deleting (`DELETE /api/issues/:id/attachments/:aid`) attachments. These endpoints enforce authentication and permissions.
- Registered the new attachment routes in the main server application. [[1]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR30) [[2]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR105)

**Project Structure and Exports**
- Exported the new `Attachment` model in the central models index for easier imports elsewhere. [[1]](diffhunk://#diff-c23cf6f4556a833ae807e2a6e07bfc50b640b106ba34527460eaddb18e020ca4R14) [[2]](diffhunk://#diff-c23cf6f4556a833ae807e2a6e07bfc50b640b106ba34527460eaddb18e020ca4L29-R31) [[3]](diffhunk://#diff-c23cf6f4556a833ae807e2a6e07bfc50b640b106ba34527460eaddb18e020ca4L43-R46)

**Testing**
- Added comprehensive tests covering uploading, file size and type validation, permissions for downloading/deleting, correct response headers, and deletion behavior.