### PR TITLE
Add report routes and tests for burndown, velocity, and issue stats

### DIFF
--- a/backend/src/routes/reportRoutes.ts
+++ b/backend/src/routes/reportRoutes.ts
@@ -1,0 +1,62 @@
+import express from 'express';
+import dashboardService from '../services/dashboardService.js';
+import { authenticateToken } from '../middleware/auth.js';
+import { formatApiResponse, formatErrorResponse } from '../utils/helpers.js';
+
+const router = express.Router();
+
+/**
+ * GET /api/projects/:id/reports/burndown?sprintId=:sprintId
+ * Returns daily burndown data (remaining story points + issue count) for a sprint.
+ * Requirements: 14.1, 14.4, 14.5
+ */
+router.get('/projects/:id/reports/burndown', authenticateToken, async (req, res) => {
+  try {
+    const { id: projectId } = req.params;
+    const { sprintId } = req.query as { sprintId?: string };
+
+    if (!sprintId) {
+      return res.status(400).json(formatErrorResponse('sprintId query parameter is required'));
+    }
+
+    const data = await dashboardService.getBurndown(projectId as string, sprintId);
+    return res.status(200).json(formatApiResponse(data, 'Burndown data retrieved successfully'));
+  } catch (error: any) {
+    console.error('getBurndown error:', error);
+    return res.status(error.statusCode || 500).json(formatErrorResponse(error.message));
+  }
+});
+
+/**
+ * GET /api/projects/:id/reports/velocity
+ * Returns per-sprint completed story points and issue count for the last 10 closed sprints.
+ * Requirements: 14.2
+ */
+router.get('/projects/:id/reports/velocity', authenticateToken, async (req, res) => {
+  try {
+    const { id: projectId } = req.params;
+    const data = await dashboardService.getVelocity(projectId as string);
+    return res.status(200).json(formatApiResponse(data, 'Velocity data retrieved successfully'));
+  } catch (error: any) {
+    console.error('getVelocity error:', error);
+    return res.status(error.statusCode || 500).json(formatErrorResponse(error.message));
+  }
+});
+
+/**
+ * GET /api/projects/:id/reports/issue-stats
+ * Returns issue counts grouped by issueType, status, priority, and assigneeId.
+ * Requirements: 14.3
+ */
+router.get('/projects/:id/reports/issue-stats', authenticateToken, async (req, res) => {
+  try {
+    const { id: projectId } = req.params;
+    const data = await dashboardService.getIssueStats(projectId as string);
+    return res.status(200).json(formatApiResponse(data, 'Issue stats retrieved successfully'));
+  } catch (error: any) {
+    console.error('getIssueStats error:', error);
+    return res.status(error.statusCode || 500).json(formatErrorResponse(error.message));
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -31,6 +31,7 @@ import attachmentRoutes from './routes/attachmentRoutes.js';
 import webhookRoutes from './routes/webhookRoutes.js';
 import auditLogRoutes from './routes/auditLogRoutes.js';
 import ssoRoutes from './routes/ssoRoutes.js';
+import reportRoutes from './routes/reportRoutes.js';
 import passportInit from './config/passport.js';
 // import aiRoutes from './routes/ai.js';
 
@@ -111,6 +112,7 @@ app.use('/api', attachmentRoutes);
 app.use('/api/webhooks', webhookRoutes);
 app.use('/api/admin/audit-logs', auditLogRoutes);
 app.use('/api/auth', ssoRoutes);
+app.use('/api', reportRoutes);
 // app.use('/api/ai', aiRoutes);
 
 // Default route

--- a/backend/src/services/dashboardService.ts
+++ b/backend/src/services/dashboardService.ts
@@ -1,5 +1,8 @@
 import { Project, Task, User, Comment, Notification, TimeEntry, ActivityLog } from '../models/index.js';
 import { snakeToCamel, formatDateForDB } from '../utils/helpers.js';
+import Issue from '../models/Issue.js';
+import Sprint from '../models/Sprint.js';
+import database from '../config/database.js';
 
 class DashboardService {
   /**
@@ -1089,6 +1092,171 @@ class DashboardService {
 
   async getProjectMilestones(projectId: string) {
     return [];
+  }
+
+  // ─── Sprint Reports (Requirements 14.1–14.5) ───────────────────────────────
+
+  /**
+   * Compute daily burndown data for a sprint.
+   * Returns an array of { date, remainingStoryPoints, remainingIssueCount } objects,
+   * one per calendar day from sprint start to sprint end (or today if still active).
+   * All story-point values are 0 (never null) when no story points are assigned.
+   */
+  async getBurndown(projectId: string, sprintId: string): Promise<any> {
+    const sprint = await Sprint.findById(sprintId);
+    if (!sprint) {
+      const err: any = new Error('Sprint not found');
+      err.statusCode = 404;
+      throw err;
+    }
+    if (sprint.projectId !== projectId) {
+      const err: any = new Error('Sprint does not belong to this project');
+      err.statusCode = 400;
+      throw err;
+    }
+
+    const startDate = sprint.startDate ? new Date(sprint.startDate) : new Date(sprint.createdAt);
+    const endDate = sprint.endDate ? new Date(sprint.endDate) : new Date();
+    const today = new Date();
+    const chartEnd = sprint.state === 'closed' ? endDate : (endDate < today ? endDate : today);
+
+    // Fetch all issues that were ever in this sprint (current sprintId OR completed in it)
+    const issuesCol = await database.getCollection('issues');
+    const sprintIssues = await issuesCol.find({ sprintId }).toArray();
+
+    // Determine done-category states from project workflow
+    let doneStates: Set<string> = new Set(['done']);
+    try {
+      const project = await Project.findById(projectId);
+      if (project?.workflow?.states) {
+        const doneStateNames = project.workflow.states
+          .filter((s: any) => s.category === 'done')
+          .map((s: any) => s.name);
+        if (doneStateNames.length > 0) {
+          doneStates = new Set(doneStateNames);
+        }
+      }
+    } catch {
+      // fallback: 'done' only
+    }
+
+    // Build daily data points
+    const dataPoints: Array<{ date: string; remainingStoryPoints: number; remainingIssueCount: number }> = [];
+    const msPerDay = 24 * 60 * 60 * 1000;
+    const totalDays = Math.max(1, Math.ceil((chartEnd.getTime() - startDate.getTime()) / msPerDay) + 1);
+
+    for (let i = 0; i < totalDays; i++) {
+      const dayEnd = new Date(startDate.getTime() + (i + 1) * msPerDay - 1);
+      const dateStr = new Date(startDate.getTime() + i * msPerDay).toISOString().slice(0, 10);
+
+      // An issue is "remaining" on this day if it was not completed by end of this day
+      const remaining = sprintIssues.filter((issue) => {
+        const isDone = doneStates.has(issue.status);
+        if (!isDone) return true; // still open
+        // completed before end of this day?
+        const completedAt = issue.completedAt ? new Date(issue.completedAt) : null;
+        return completedAt ? completedAt > dayEnd : true;
+      });
+
+      const remainingStoryPoints = remaining.reduce(
+        (sum, i) => sum + (typeof i.storyPoints === 'number' ? i.storyPoints : 0),
+        0
+      );
+
+      dataPoints.push({
+        date: dateStr,
+        remainingStoryPoints,
+        remainingIssueCount: remaining.length,
+      });
+    }
+
+    return {
+      sprintId,
+      sprintName: sprint.name,
+      startDate: startDate.toISOString().slice(0, 10),
+      endDate: endDate.toISOString().slice(0, 10),
+      state: sprint.state,
+      dataPoints,
+    };
+  }
+
+  /**
+   * Return per-sprint completed story points and issue count for the last 10 closed sprints.
+   * Story point values are always 0 (never null/undefined).
+   */
+  async getVelocity(projectId: string): Promise<any> {
+    const project = await Project.findById(projectId);
+    if (!project) {
+      const err: any = new Error('Project not found');
+      err.statusCode = 404;
+      throw err;
+    }
+
+    const allSprints = await Sprint.findByProject(projectId, { state: 'closed' });
+    // Sort by endDate descending, take last 10
+    const closed = allSprints
+      .sort((a, b) => {
+        const aEnd = a.endDate ? new Date(a.endDate).getTime() : 0;
+        const bEnd = b.endDate ? new Date(b.endDate).getTime() : 0;
+        return bEnd - aEnd;
+      })
+      .slice(0, 10)
+      .reverse(); // chronological order for chart
+
+    const velocityData = closed.map((sprint) => ({
+      sprintId: sprint.id,
+      sprintName: sprint.name,
+      startDate: sprint.startDate ? new Date(sprint.startDate).toISOString().slice(0, 10) : null,
+      endDate: sprint.endDate ? new Date(sprint.endDate).toISOString().slice(0, 10) : null,
+      completedStoryPoints: typeof sprint.completedStoryPoints === 'number' ? sprint.completedStoryPoints : 0,
+      completedIssueCount: typeof sprint.completedIssueCount === 'number' ? sprint.completedIssueCount : 0,
+    }));
+
+    return { projectId, velocityData };
+  }
+
+  /**
+   * Return issue counts grouped by issueType, status, priority, and assigneeId.
+   */
+  async getIssueStats(projectId: string): Promise<any> {
+    const project = await Project.findById(projectId);
+    if (!project) {
+      const err: any = new Error('Project not found');
+      err.statusCode = 404;
+      throw err;
+    }
+
+    const issuesCol = await database.getCollection('issues');
+    const issues = await issuesCol.find({ projectId }).toArray();
+
+    const byIssueType: Record<string, number> = {};
+    const byStatus: Record<string, number> = {};
+    const byPriority: Record<string, number> = {};
+    const byAssigneeId: Record<string, number> = {};
+
+    for (const issue of issues) {
+      const type = issue.issueType || 'task';
+      byIssueType[type] = (byIssueType[type] || 0) + 1;
+
+      const status = issue.status || 'todo';
+      byStatus[status] = (byStatus[status] || 0) + 1;
+
+      const priority = issue.priority || 'medium';
+      byPriority[priority] = (byPriority[priority] || 0) + 1;
+
+      if (issue.assignedTo) {
+        byAssigneeId[issue.assignedTo] = (byAssigneeId[issue.assignedTo] || 0) + 1;
+      }
+    }
+
+    return {
+      projectId,
+      total: issues.length,
+      byIssueType,
+      byStatus,
+      byPriority,
+      byAssigneeId,
+    };
   }
 }
 

--- a/backend/tests/properties/reportProperties.test.ts
+++ b/backend/tests/properties/reportProperties.test.ts
@@ -1,0 +1,477 @@
+// Feature: jira-level-platform, Property 20: Burndown final data point invariant
+
+/**
+ * Property-based tests for the burndown chart computation.
+ * Feature: jira-level-platform
+ * Validates: Requirements 14.5
+ */
+
+import * as fc from 'fast-check';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// Inline types — mirrors the Issue and Sprint shapes used by getBurndown
+// ---------------------------------------------------------------------------
+
+interface SprintLike {
+  id: string;
+  projectId: string;
+  name: string;
+  state: 'created' | 'active' | 'closed';
+  startDate: Date;
+  endDate: Date;
+}
+
+interface IssueLike {
+  id: string;
+  sprintId: string;
+  status: string;
+  storyPoints: number | null | undefined;
+  completedAt: Date | null | undefined;
+}
+
+interface BurndownDataPoint {
+  date: string;
+  remainingStoryPoints: number;
+  remainingIssueCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pure burndown computation — extracted from DashboardService.getBurndown
+// This mirrors the exact logic in the service without any DB calls.
+// ---------------------------------------------------------------------------
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Compute daily burndown data points for a sprint.
+ * Mirrors the logic in DashboardService.getBurndown.
+ */
+function computeBurndown(
+  sprint: SprintLike,
+  issues: IssueLike[],
+  doneStates: Set<string>,
+): BurndownDataPoint[] {
+  const startDate = sprint.startDate;
+  const endDate = sprint.endDate;
+  // For a closed sprint, chartEnd = endDate
+  const chartEnd = sprint.state === 'closed' ? endDate : new Date();
+
+  const totalDays = Math.max(
+    1,
+    Math.ceil((chartEnd.getTime() - startDate.getTime()) / MS_PER_DAY) + 1,
+  );
+
+  const dataPoints: BurndownDataPoint[] = [];
+
+  for (let i = 0; i < totalDays; i++) {
+    const dayEnd = new Date(startDate.getTime() + (i + 1) * MS_PER_DAY - 1);
+    const dateStr = new Date(startDate.getTime() + i * MS_PER_DAY).toISOString().slice(0, 10);
+
+    // An issue is "remaining" on this day if it was not completed by end of this day
+    const remaining = issues.filter((issue) => {
+      const isDone = doneStates.has(issue.status);
+      if (!isDone) return true; // still open
+      // completed before end of this day?
+      const completedAt = issue.completedAt ? new Date(issue.completedAt) : null;
+      return completedAt ? completedAt > dayEnd : true;
+    });
+
+    const remainingStoryPoints = remaining.reduce(
+      (sum, issue) => sum + (typeof issue.storyPoints === 'number' ? issue.storyPoints : 0),
+      0,
+    );
+
+    dataPoints.push({
+      date: dateStr,
+      remainingStoryPoints,
+      remainingIssueCount: remaining.length,
+    });
+  }
+
+  return dataPoints;
+}
+
+/**
+ * Compute the dayEnd timestamp for the final burndown data point of a closed sprint.
+ * This matches the burndown computation: dayEnd for the last day index.
+ */
+function getFinalDayEnd(sprint: SprintLike): Date {
+  const startDate = sprint.startDate;
+  const endDate = sprint.endDate;
+  const totalDays = Math.max(
+    1,
+    Math.ceil((endDate.getTime() - startDate.getTime()) / MS_PER_DAY) + 1,
+  );
+  // Last day index = totalDays - 1
+  return new Date(startDate.getTime() + totalDays * MS_PER_DAY - 1);
+}
+
+/**
+ * Compute the expected remaining story points for the final burndown data point
+ * of a closed sprint: sum of storyPoints of issues that are NOT completed by
+ * the final day's end timestamp (matching the burndown's dayEnd logic).
+ *
+ * This is the mathematical invariant from Requirement 14.5.
+ */
+function computeExpectedFinalRemainingPoints(
+  issues: IssueLike[],
+  doneStates: Set<string>,
+  finalDayEnd: Date,
+): number {
+  return issues
+    .filter((issue) => {
+      const isDone = doneStates.has(issue.status);
+      if (!isDone) return true; // incomplete — counts as remaining
+      // Done but completed after final day end — also counts as remaining
+      const completedAt = issue.completedAt ? new Date(issue.completedAt) : null;
+      return completedAt ? completedAt > finalDayEnd : true;
+    })
+    .reduce(
+      (sum, issue) => sum + (typeof issue.storyPoints === 'number' ? issue.storyPoints : 0),
+      0,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Arbitraries
+// ---------------------------------------------------------------------------
+
+/** Non-negative integer story points (0–100), or null/undefined */
+const storyPointsArb = fc.oneof(
+  fc.constant(null),
+  fc.constant(undefined),
+  fc.nat({ max: 100 }),
+);
+
+/** Done-category state names */
+const doneStatusArb = fc.constantFrom('Done', 'Closed', 'Resolved', 'done');
+
+/** Non-done state names */
+const openStatusArb = fc.constantFrom('To Do', 'In Progress', 'In Review', 'Backlog', 'todo');
+
+/** Any status (done or open) */
+const anyStatusArb = fc.oneof(doneStatusArb, openStatusArb);
+
+/** The set of done states used in tests */
+const DONE_STATES = new Set(['Done', 'Closed', 'Resolved', 'done']);
+
+/**
+ * Generates a closed sprint with a valid date range (startDate < endDate).
+ * The sprint is always in 'closed' state to match the property requirement.
+ * Duration is 1–30 days to avoid NaN or zero-duration issues.
+ * Uses integer timestamps to avoid NaN date issues.
+ */
+const BASE_TIMESTAMP = new Date('2020-01-01').getTime();
+const MAX_START_OFFSET_MS = (365 * 9) * MS_PER_DAY; // up to 9 years from base
+
+const closedSprintArb: fc.Arbitrary<SprintLike> = fc
+  .tuple(
+    fc.integer({ min: 0, max: MAX_START_OFFSET_MS }),
+    fc.integer({ min: 1, max: 30 }),
+  )
+  .map(([startOffsetMs, durationDays]) => {
+    const startDate = new Date(BASE_TIMESTAMP + startOffsetMs);
+    const endDate = new Date(startDate.getTime() + durationDays * MS_PER_DAY);
+    return {
+      id: 'sprint-test-001',
+      projectId: 'project-test-001',
+      name: 'Test Sprint',
+      state: 'closed' as const,
+      startDate,
+      endDate,
+    };
+  });
+
+/**
+ * Generates an issue for a given sprint.
+ * completedAt is either null (not completed), during the sprint, or after sprint end.
+ * Uses integer offsets in whole seconds to avoid fractional values.
+ */
+function issueArb(sprint: SprintLike): fc.Arbitrary<IssueLike> {
+  // Sprint duration in whole seconds (guaranteed >= 86400 since min 1 day)
+  const durationSecs = Math.floor((sprint.endDate.getTime() - sprint.startDate.getTime()) / 1000);
+
+  return fc.record({
+    id: fc.stringMatching(/^issue-[a-z0-9]{4,8}$/),
+    sprintId: fc.constant(sprint.id),
+    status: anyStatusArb,
+    storyPoints: storyPointsArb,
+    // completedAt: null, during sprint, or after sprint end
+    completedAt: fc.oneof(
+      fc.constant(null),
+      // completed during sprint (0 to durationSecs - 1 seconds after start)
+      fc.integer({ min: 0, max: durationSecs - 1 }).map(
+        (offsetSecs) => new Date(sprint.startDate.getTime() + offsetSecs * 1000),
+      ),
+      // completed after sprint end (1 to 7 days after end)
+      fc.integer({ min: 1, max: 7 * 24 * 3600 }).map(
+        (offsetSecs) => new Date(sprint.endDate.getTime() + offsetSecs * 1000),
+      ),
+    ),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Property 20: Burndown final data point invariant
+// Feature: jira-level-platform, Property 20: Burndown final data point invariant
+// ---------------------------------------------------------------------------
+
+describe('Property 20: Burndown final data point invariant', () => {
+  // **Validates: Requirements 14.5**
+
+  it('final burndown data point remainingStoryPoints equals sum of incomplete issue story points', () => {
+    // Feature: jira-level-platform, Property 20: Burndown final data point invariant
+    fc.assert(
+      fc.property(
+        closedSprintArb.chain((sprint) =>
+          fc.tuple(
+            fc.constant(sprint),
+            fc.array(issueArb(sprint), { minLength: 0, maxLength: 20 }),
+          ),
+        ),
+        ([sprint, issues]) => {
+          const dataPoints = computeBurndown(sprint, issues, DONE_STATES);
+
+          assert.ok(dataPoints.length > 0, 'Burndown must have at least one data point');
+
+          const finalDataPoint = dataPoints[dataPoints.length - 1];
+          const finalDayEnd = getFinalDayEnd(sprint);
+
+          // Compute expected remaining story points independently using the same dayEnd logic
+          const expected = computeExpectedFinalRemainingPoints(issues, DONE_STATES, finalDayEnd);
+
+          assert.equal(
+            finalDataPoint.remainingStoryPoints,
+            expected,
+            `Final burndown remainingStoryPoints (${finalDataPoint.remainingStoryPoints}) ` +
+              `must equal sum of incomplete issue story points (${expected})`,
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('final burndown remainingStoryPoints is 0 when all issues are completed before sprint end', () => {
+    // Feature: jira-level-platform, Property 20: Burndown final data point invariant
+    fc.assert(
+      fc.property(
+        closedSprintArb.chain((sprint) => {
+          // Sprint duration in whole seconds (min 1 day = 86400 secs)
+          // Use integer arithmetic to avoid floating point issues
+          const durationMs = sprint.endDate.getTime() - sprint.startDate.getTime();
+          const durationSecs = Math.floor(durationMs / 1000);
+          // Ensure max >= min (durationSecs is always >= 86400 for 1-day sprints)
+          const maxOffsetSecs = Math.max(1, durationSecs - 1);
+          return fc.tuple(
+            fc.constant(sprint),
+            fc.array(
+              fc.record({
+                id: fc.stringMatching(/^issue-[a-z0-9]{4,8}$/),
+                sprintId: fc.constant(sprint.id),
+                status: doneStatusArb,
+                storyPoints: fc.nat({ max: 50 }),
+                // completedAt is strictly before sprint endDate (within sprint duration)
+                completedAt: fc
+                  .integer({ min: 0, max: maxOffsetSecs })
+                  .map(
+                    (offsetSecs) =>
+                      new Date(sprint.startDate.getTime() + offsetSecs * 1000),
+                  ),
+              }),
+              { minLength: 1, maxLength: 10 },
+            ),
+          );
+        }),
+        ([sprint, issues]) => {
+          const dataPoints = computeBurndown(sprint, issues, DONE_STATES);
+          const finalDataPoint = dataPoints[dataPoints.length - 1];
+
+          assert.equal(
+            finalDataPoint.remainingStoryPoints,
+            0,
+            `When all issues are completed before sprint end, final remainingStoryPoints must be 0`,
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('final burndown remainingStoryPoints equals total story points when no issues are completed', () => {
+    // Feature: jira-level-platform, Property 20: Burndown final data point invariant
+    fc.assert(
+      fc.property(
+        closedSprintArb.chain((sprint) =>
+          fc.tuple(
+            fc.constant(sprint),
+            fc.array(
+              fc.record({
+                id: fc.stringMatching(/^issue-[a-z0-9]{4,8}$/),
+                sprintId: fc.constant(sprint.id),
+                status: openStatusArb,
+                storyPoints: fc.nat({ max: 50 }),
+                completedAt: fc.constant(null),
+              }),
+              { minLength: 0, maxLength: 10 },
+            ),
+          ),
+        ),
+        ([sprint, issues]) => {
+          const dataPoints = computeBurndown(sprint, issues, DONE_STATES);
+          const finalDataPoint = dataPoints[dataPoints.length - 1];
+
+          const totalStoryPoints = issues.reduce(
+            (sum, issue) => sum + (typeof issue.storyPoints === 'number' ? issue.storyPoints : 0),
+            0,
+          );
+
+          assert.equal(
+            finalDataPoint.remainingStoryPoints,
+            totalStoryPoints,
+            `When no issues are completed, final remainingStoryPoints must equal total story points (${totalStoryPoints})`,
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('final burndown remainingStoryPoints is 0 for a sprint with no issues', () => {
+    // Feature: jira-level-platform, Property 20: Burndown final data point invariant
+    fc.assert(
+      fc.property(closedSprintArb, (sprint) => {
+        const dataPoints = computeBurndown(sprint, [], DONE_STATES);
+
+        assert.ok(dataPoints.length > 0, 'Burndown must have at least one data point');
+
+        const finalDataPoint = dataPoints[dataPoints.length - 1];
+
+        assert.equal(
+          finalDataPoint.remainingStoryPoints,
+          0,
+          'A sprint with no issues must have 0 remaining story points',
+        );
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it('issues with null/undefined storyPoints contribute 0 to remaining story points', () => {
+    // Feature: jira-level-platform, Property 20: Burndown final data point invariant
+    fc.assert(
+      fc.property(
+        closedSprintArb.chain((sprint) =>
+          fc.tuple(
+            fc.constant(sprint),
+            fc.array(
+              fc.record({
+                id: fc.stringMatching(/^issue-[a-z0-9]{4,8}$/),
+                sprintId: fc.constant(sprint.id),
+                status: openStatusArb,
+                storyPoints: fc.oneof(fc.constant(null), fc.constant(undefined)),
+                completedAt: fc.constant(null),
+              }),
+              { minLength: 1, maxLength: 10 },
+            ),
+          ),
+        ),
+        ([sprint, issues]) => {
+          const dataPoints = computeBurndown(sprint, issues, DONE_STATES);
+          const finalDataPoint = dataPoints[dataPoints.length - 1];
+
+          assert.equal(
+            finalDataPoint.remainingStoryPoints,
+            0,
+            'Issues with null/undefined storyPoints must contribute 0 to remaining story points',
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('final burndown remainingIssueCount equals count of incomplete issues', () => {
+    // Feature: jira-level-platform, Property 20: Burndown final data point invariant
+    fc.assert(
+      fc.property(
+        closedSprintArb.chain((sprint) =>
+          fc.tuple(
+            fc.constant(sprint),
+            fc.array(issueArb(sprint), { minLength: 0, maxLength: 20 }),
+          ),
+        ),
+        ([sprint, issues]) => {
+          const dataPoints = computeBurndown(sprint, issues, DONE_STATES);
+          const finalDataPoint = dataPoints[dataPoints.length - 1];
+          const finalDayEnd = getFinalDayEnd(sprint);
+
+          // Count incomplete issues using the same dayEnd logic as the burndown
+          const expectedCount = issues.filter((issue) => {
+            const isDone = DONE_STATES.has(issue.status);
+            if (!isDone) return true;
+            const completedAt = issue.completedAt ? new Date(issue.completedAt) : null;
+            return completedAt ? completedAt > finalDayEnd : true;
+          }).length;
+
+          assert.equal(
+            finalDataPoint.remainingIssueCount,
+            expectedCount,
+            `Final burndown remainingIssueCount (${finalDataPoint.remainingIssueCount}) ` +
+              `must equal count of incomplete issues (${expectedCount})`,
+          );
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  it('burndown data points are non-increasing in remainingStoryPoints over time', () => {
+    // Feature: jira-level-platform, Property 20: Burndown final data point invariant
+    // As issues get completed over time, remaining story points can only decrease or stay the same.
+    fc.assert(
+      fc.property(
+        closedSprintArb.chain((sprint) => {
+          const durationSecs = Math.floor(
+            (sprint.endDate.getTime() - sprint.startDate.getTime()) / 1000,
+          );
+          return fc.tuple(
+            fc.constant(sprint),
+            fc.array(
+              fc.record({
+                id: fc.stringMatching(/^issue-[a-z0-9]{4,8}$/),
+                sprintId: fc.constant(sprint.id),
+                // All issues are in done state
+                status: doneStatusArb,
+                storyPoints: fc.nat({ max: 20 }),
+                // completedAt is within the sprint duration
+                completedAt: fc
+                  .integer({ min: 0, max: durationSecs - 1 })
+                  .map(
+                    (offsetSecs) =>
+                      new Date(sprint.startDate.getTime() + offsetSecs * 1000),
+                  ),
+              }),
+              { minLength: 0, maxLength: 15 },
+            ),
+          );
+        }),
+        ([sprint, issues]) => {
+          const dataPoints = computeBurndown(sprint, issues, DONE_STATES);
+
+          // Remaining story points must be non-increasing over time
+          for (let i = 1; i < dataPoints.length; i++) {
+            assert.ok(
+              dataPoints[i].remainingStoryPoints <= dataPoints[i - 1].remainingStoryPoints,
+              `Burndown must be non-increasing: day ${i - 1} had ` +
+                `${dataPoints[i - 1].remainingStoryPoints} but day ${i} has ` +
+                `${dataPoints[i].remainingStoryPoints}`,
+            );
+          }
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/backend/tests/reports.test.mjs
+++ b/backend/tests/reports.test.mjs
@@ -1,0 +1,497 @@
+import { describe, test, expect, beforeAll, beforeEach, jest } from '@jest/globals';
+import request from 'supertest';
+import app from '../src/server.ts';
+import database from '../src/config/database.ts';
+import { cleanupUsersByEmails, clearProjectDomainData } from './dbTestUtils.mjs';
+
+// Requirements: 14.1–14.5
+jest.setTimeout(30000);
+
+async function registerAndLogin(user) {
+  const reg = await request(app).post('/api/auth/register').send(user).expect(201);
+  const token = reg.body.data.token;
+  const me = await request(app).get('/api/auth/me').set('Authorization', `Bearer ${token}`).expect(200);
+  return { token, user: me.body.data };
+}
+
+const yesterday = new Date(Date.now() - 86400000).toISOString();
+const nextWeek = new Date(Date.now() + 86400000 * 7).toISOString();
+
+describe('Reports API', () => {
+  let manager;
+
+  beforeAll(async () => {
+    await cleanupUsersByEmails(['reports-mgr@example.com']);
+    manager = await registerAndLogin({
+      email: 'reports-mgr@example.com',
+      password: 'Password123!',
+      firstName: 'ReportsMgr',
+      lastName: 'User',
+      role: 'manager',
+    });
+  });
+
+  async function setupProjectAndSprint({ withIssues = [] } = {}) {
+    await clearProjectDomainData();
+    const db = await database.connect();
+    await db.collection('issues').deleteMany({});
+    await db.collection('sprints').deleteMany({});
+
+    // Create project
+    const projRes = await request(app)
+      .post('/api/projects')
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'Reports Test Project' })
+      .expect(201);
+    const projectId = projRes.body.data.id;
+
+    // Create and start a sprint
+    const sprintRes = await request(app)
+      .post(`/api/projects/${projectId}/sprints`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .send({ name: 'Sprint 1', startDate: yesterday, endDate: nextWeek })
+      .expect(201);
+    const sprintId = sprintRes.body.data.id;
+
+    await request(app)
+      .post(`/api/sprints/${sprintId}/start`)
+      .set('Authorization', `Bearer ${manager.token}`)
+      .expect(200);
+
+    // Create issues in the sprint
+    const issueIds = [];
+    for (const issueData of withIssues) {
+      const issueRes = await request(app)
+        .post('/api/issues')
+        .set('Authorization', `Bearer ${manager.token}`)
+        .send({ projectId, createdBy: manager.user.id, sprintId, ...issueData })
+        .expect(201);
+      issueIds.push(issueRes.body.data.id);
+    }
+
+    return { projectId, sprintId, issueIds };
+  }
+
+  // ─── Burndown Chart (Requirement 14.1) ────────────────────────────────────
+
+  describe('GET /api/projects/:id/reports/burndown', () => {
+    test('returns 400 when sprintId query param is missing', async () => {
+      const { projectId } = await setupProjectAndSprint();
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/burndown`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(400);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    test('returns 404 for non-existent sprint', async () => {
+      const { projectId } = await setupProjectAndSprint();
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/burndown?sprintId=000000000000000000000000`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(404);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    test('returns burndown data with correct shape', async () => {
+      const { projectId, sprintId } = await setupProjectAndSprint({
+        withIssues: [
+          { title: 'Issue A', storyPoints: 3, issueType: 'task' },
+          { title: 'Issue B', storyPoints: 5, issueType: 'task' },
+        ],
+      });
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/burndown?sprintId=${sprintId}`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      const data = res.body.data;
+      expect(data.sprintId).toBe(sprintId);
+      expect(data.sprintName).toBe('Sprint 1');
+      expect(Array.isArray(data.dataPoints)).toBe(true);
+      expect(data.dataPoints.length).toBeGreaterThanOrEqual(1);
+
+      // Each data point must have the required fields
+      for (const point of data.dataPoints) {
+        expect(typeof point.date).toBe('string');
+        expect(typeof point.remainingStoryPoints).toBe('number');
+        expect(typeof point.remainingIssueCount).toBe('number');
+      }
+    });
+
+    test('burndown data points reflect total story points at start', async () => {
+      const { projectId, sprintId } = await setupProjectAndSprint({
+        withIssues: [
+          { title: 'Issue A', storyPoints: 3, issueType: 'task' },
+          { title: 'Issue B', storyPoints: 5, issueType: 'task' },
+        ],
+      });
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/burndown?sprintId=${sprintId}`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const firstPoint = res.body.data.dataPoints[0];
+      // Both issues are open, so remaining story points should be 8
+      expect(firstPoint.remainingStoryPoints).toBe(8);
+      expect(firstPoint.remainingIssueCount).toBe(2);
+    });
+
+    // Requirement 14.4 — zero story points returns 0 not null
+    test('returns 0 (not null) for story points when no story points assigned', async () => {
+      const { projectId, sprintId } = await setupProjectAndSprint({
+        withIssues: [
+          { title: 'No Points Issue', issueType: 'task' }, // no storyPoints field
+        ],
+      });
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/burndown?sprintId=${sprintId}`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      for (const point of res.body.data.dataPoints) {
+        expect(point.remainingStoryPoints).toBe(0);
+        expect(point.remainingStoryPoints).not.toBeNull();
+        expect(point.remainingStoryPoints).not.toBeUndefined();
+      }
+    });
+
+    test('returns 0 story points for sprint with no issues', async () => {
+      const { projectId, sprintId } = await setupProjectAndSprint({ withIssues: [] });
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/burndown?sprintId=${sprintId}`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      for (const point of res.body.data.dataPoints) {
+        expect(point.remainingStoryPoints).toBe(0);
+        expect(point.remainingIssueCount).toBe(0);
+      }
+    });
+
+    // Requirement 14.5 — final data point invariant for closed sprint
+    // Note: The implementation clears sprintId on incomplete issues when closing a sprint
+    // (moving them to backlog). The burndown for a closed sprint therefore shows 0 remaining
+    // for incomplete issues (they're no longer in the sprint). The completed issue remains
+    // queryable by sprintId and shows 0 remaining story points (it's done).
+    test('final burndown data point shows 0 remaining after sprint close with all issues resolved', async () => {
+      const { projectId, sprintId, issueIds } = await setupProjectAndSprint({
+        withIssues: [
+          { title: 'Complete Me', storyPoints: 3, issueType: 'task' },
+        ],
+      });
+
+      // Set up a workflow with lowercase state names matching the default issue status 'todo'
+      const workflow = {
+        states: [
+          { name: 'todo', category: 'todo', transitions: ['done'] },
+          { name: 'done', category: 'done', transitions: [] },
+        ],
+      };
+      await request(app)
+        .put(`/api/projects/${projectId}`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .send({ workflow })
+        .expect(200);
+
+      // Transition the issue to done
+      await request(app)
+        .post(`/api/issues/${issueIds[0]}/transition`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .send({ targetState: 'done' })
+        .expect(200);
+
+      // Close the sprint
+      await request(app)
+        .post(`/api/sprints/${sprintId}/close`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/burndown?sprintId=${sprintId}`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const dataPoints = res.body.data.dataPoints;
+      const lastPoint = dataPoints[dataPoints.length - 1];
+
+      // The completed issue is in 'done' state, so remaining = 0
+      expect(lastPoint.remainingStoryPoints).toBe(0);
+      expect(lastPoint.remainingIssueCount).toBe(0);
+    });
+
+    test('requires authentication', async () => {
+      const { projectId, sprintId } = await setupProjectAndSprint();
+
+      await request(app)
+        .get(`/api/projects/${projectId}/reports/burndown?sprintId=${sprintId}`)
+        .expect(401);
+    });
+  });
+
+  // ─── Velocity Chart (Requirement 14.2) ────────────────────────────────────
+
+  describe('GET /api/projects/:id/reports/velocity', () => {
+    test('returns 404 for non-existent project', async () => {
+      const res = await request(app)
+        .get('/api/projects/000000000000000000000000/reports/velocity')
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(404);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    test('returns velocity data with correct shape', async () => {
+      const { projectId } = await setupProjectAndSprint();
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/velocity`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      const data = res.body.data;
+      expect(data.projectId).toBe(projectId);
+      expect(Array.isArray(data.velocityData)).toBe(true);
+    });
+
+    test('returns empty velocityData when no closed sprints exist', async () => {
+      const { projectId } = await setupProjectAndSprint(); // sprint is active, not closed
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/velocity`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      expect(res.body.data.velocityData).toHaveLength(0);
+    });
+
+    test('returns velocity entry for a closed sprint', async () => {
+      const { projectId, sprintId } = await setupProjectAndSprint({
+        withIssues: [
+          { title: 'Done Issue', storyPoints: 8, issueType: 'task' },
+        ],
+      });
+
+      // Transition issue to done then close sprint
+      const db = await database.connect();
+      const issuesCol = db.collection('issues');
+      await issuesCol.updateOne({ sprintId }, { $set: { status: 'Done', completedAt: new Date() } });
+
+      await request(app)
+        .post(`/api/sprints/${sprintId}/close`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/velocity`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      expect(res.body.data.velocityData.length).toBeGreaterThanOrEqual(1);
+      const entry = res.body.data.velocityData[0];
+      expect(entry.sprintId).toBe(sprintId);
+      expect(typeof entry.completedStoryPoints).toBe('number');
+      expect(typeof entry.completedIssueCount).toBe('number');
+    });
+
+    test('velocity entry story points are 0 (not null) when sprint has no story points', async () => {
+      const { projectId, sprintId } = await setupProjectAndSprint({
+        withIssues: [{ title: 'No Points', issueType: 'task' }],
+      });
+
+      await request(app)
+        .post(`/api/sprints/${sprintId}/close`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/velocity`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const entry = res.body.data.velocityData.find((v) => v.sprintId === sprintId);
+      expect(entry).toBeDefined();
+      expect(entry.completedStoryPoints).toBe(0);
+      expect(entry.completedStoryPoints).not.toBeNull();
+      expect(entry.completedIssueCount).toBe(0);
+      expect(entry.completedIssueCount).not.toBeNull();
+    });
+
+    test('returns at most 10 closed sprints', async () => {
+      await clearProjectDomainData();
+      const db = await database.connect();
+      await db.collection('issues').deleteMany({});
+      await db.collection('sprints').deleteMany({});
+
+      const projRes = await request(app)
+        .post('/api/projects')
+        .set('Authorization', `Bearer ${manager.token}`)
+        .send({ name: 'Velocity 10 Sprints Project' })
+        .expect(201);
+      const projectId = projRes.body.data.id;
+
+      // Insert 12 closed sprints directly into the DB to avoid slow API calls
+      const sprintsCol = db.collection('sprints');
+      const now = new Date();
+      const sprintDocs = Array.from({ length: 12 }, (_, i) => ({
+        projectId,
+        name: `Sprint ${i + 1}`,
+        state: 'closed',
+        startDate: new Date(now.getTime() - (12 - i) * 14 * 86400000),
+        endDate: new Date(now.getTime() - (11 - i) * 14 * 86400000),
+        completedStoryPoints: i * 2,
+        completedIssueCount: i,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }));
+      await sprintsCol.insertMany(sprintDocs);
+
+      const res = await request(app)
+        .get(`/api/projects/${projectId}/reports/velocity`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      expect(res.body.data.velocityData.length).toBeLessThanOrEqual(10);
+    });
+
+    test('requires authentication', async () => {
+      const { projectId } = await setupProjectAndSprint();
+
+      await request(app)
+        .get(`/api/projects/${projectId}/reports/velocity`)
+        .expect(401);
+    });
+  });
+
+  // ─── Issue Stats (Requirement 14.3) ───────────────────────────────────────
+
+  describe('GET /api/projects/:id/reports/issue-stats', () => {
+    let sharedProjectId;
+    let sharedSprintId;
+
+    beforeAll(async () => {
+      // Create a shared project + sprint for issue-stats tests to avoid rate limiting
+      const setup = await setupProjectAndSprint({
+        withIssues: [
+          { title: 'Shared Task 1', issueType: 'task', priority: 'high' },
+          { title: 'Shared Bug 1', issueType: 'bug', priority: 'critical' },
+          { title: 'Shared Epic 1', issueType: 'epic', priority: 'medium' },
+        ],
+      });
+      sharedProjectId = setup.projectId;
+      sharedSprintId = setup.sprintId;
+    });
+
+    test('returns 404 for non-existent project', async () => {
+      const res = await request(app)
+        .get('/api/projects/000000000000000000000000/reports/issue-stats')
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(404);
+
+      expect(res.body.success).toBe(false);
+    });
+
+    test('returns issue stats with correct shape', async () => {
+      const res = await request(app)
+        .get(`/api/projects/${sharedProjectId}/reports/issue-stats`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      const data = res.body.data;
+      expect(data.projectId).toBe(sharedProjectId);
+      expect(typeof data.total).toBe('number');
+      expect(typeof data.byIssueType).toBe('object');
+      expect(typeof data.byStatus).toBe('object');
+      expect(typeof data.byPriority).toBe('object');
+      expect(typeof data.byAssigneeId).toBe('object');
+    });
+
+    test('groups issues correctly by issueType', async () => {
+      const res = await request(app)
+        .get(`/api/projects/${sharedProjectId}/reports/issue-stats`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const { byIssueType, total } = res.body.data;
+      expect(total).toBeGreaterThanOrEqual(3);
+      expect(byIssueType.task).toBeGreaterThanOrEqual(1);
+      expect(byIssueType.bug).toBeGreaterThanOrEqual(1);
+      expect(byIssueType.epic).toBeGreaterThanOrEqual(1);
+    });
+
+    test('groups issues correctly by priority', async () => {
+      const res = await request(app)
+        .get(`/api/projects/${sharedProjectId}/reports/issue-stats`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const { byPriority } = res.body.data;
+      expect(byPriority.high).toBeGreaterThanOrEqual(1);
+      expect(byPriority.critical).toBeGreaterThanOrEqual(1);
+      expect(byPriority.medium).toBeGreaterThanOrEqual(1);
+    });
+
+    test('groups issues correctly by status', async () => {
+      const res = await request(app)
+        .get(`/api/projects/${sharedProjectId}/reports/issue-stats`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const { byStatus } = res.body.data;
+      // All issues start in 'todo' state
+      const totalGrouped = Object.values(byStatus).reduce((sum, count) => sum + count, 0);
+      expect(totalGrouped).toBeGreaterThanOrEqual(3);
+    });
+
+    test('returns total count matching sum of byIssueType counts', async () => {
+      const res = await request(app)
+        .get(`/api/projects/${sharedProjectId}/reports/issue-stats`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      const { total, byIssueType } = res.body.data;
+      const sumByType = Object.values(byIssueType).reduce((sum, count) => sum + count, 0);
+      expect(sumByType).toBe(total);
+    });
+
+    test('returns zero counts for project with no issues', async () => {
+      // Create a fresh project with no issues directly via DB to avoid rate limiting
+      const db = await database.connect();
+      const projectsCol = db.collection('projects');
+      const result = await projectsCol.insertOne({
+        name: 'Empty Project',
+        status: 'active',
+        priority: 'medium',
+        createdBy: manager.user.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      const emptyProjectId = result.insertedId.toHexString();
+
+      const res = await request(app)
+        .get(`/api/projects/${emptyProjectId}/reports/issue-stats`)
+        .set('Authorization', `Bearer ${manager.token}`)
+        .expect(200);
+
+      expect(res.body.data.total).toBe(0);
+      expect(Object.keys(res.body.data.byIssueType)).toHaveLength(0);
+    });
+
+    test('requires authentication', async () => {
+      await request(app)
+        .get(`/api/projects/${sharedProjectId}/reports/issue-stats`)
+        .expect(401);
+    });
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import BacklogPage from './pages/BacklogPage';
 import SprintsPage from './pages/SprintsPage';
 import IssueDetailPage from './pages/IssueDetailPage';
 import SSOCallbackPage from './pages/SSOCallbackPage';
+import ReportsPage from './pages/ReportsPage';
 
 // Create a client
 const queryClient = new QueryClient({
@@ -80,6 +81,7 @@ function App() {
                 <Route path="projects/:id/board" element={<BoardPage />} />
                 <Route path="projects/:id/backlog" element={<BacklogPage />} />
                 <Route path="projects/:id/sprints" element={<SprintsPage />} />
+                <Route path="projects/:id/reports" element={<ReportsPage />} />
                 <Route path="issues/:id" element={<IssueDetailPage />} />
               </Route>
 

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -1,0 +1,401 @@
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+} from 'recharts';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import { Badge } from '../components/ui/badge';
+import { reportService, sprintService } from '../services/issueService';
+
+// ─── Colour palette ──────────────────────────────────────────────────────────
+const COLORS = ['#6366f1', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6', '#14b8a6'];
+
+const priorityColor: Record<string, string> = {
+  critical: '#ef4444',
+  high: '#f97316',
+  medium: '#f59e0b',
+  low: '#22c55e',
+};
+
+// ─── Burndown Tab ─────────────────────────────────────────────────────────────
+const BurndownTab: React.FC<{ projectId: string }> = ({ projectId }) => {
+  const [selectedSprintId, setSelectedSprintId] = useState<string>('');
+
+  const { data: sprints = [] } = useQuery({
+    queryKey: ['sprints', projectId],
+    queryFn: () => sprintService.getSprints(projectId),
+    enabled: !!projectId,
+  });
+
+  // Auto-select the first sprint when list loads
+  React.useEffect(() => {
+    if (sprints.length > 0 && !selectedSprintId) {
+      // Prefer active sprint, then most recent
+      const active = sprints.find((s) => s.state === 'active');
+      setSelectedSprintId(active?._id ?? sprints[0]._id);
+    }
+  }, [sprints, selectedSprintId]);
+
+  const { data: burndown, isLoading, error } = useQuery({
+    queryKey: ['burndown', projectId, selectedSprintId],
+    queryFn: () => reportService.getBurndown(projectId, selectedSprintId),
+    enabled: !!selectedSprintId,
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <span className="text-sm font-medium">Sprint</span>
+        <Select value={selectedSprintId} onValueChange={setSelectedSprintId}>
+          <SelectTrigger className="w-56">
+            <SelectValue placeholder="Select a sprint" />
+          </SelectTrigger>
+          <SelectContent>
+            {sprints.map((s) => (
+              <SelectItem key={s._id} value={s._id}>
+                {s.name}
+                <Badge
+                  className={`ml-2 text-xs ${
+                    s.state === 'active'
+                      ? 'bg-blue-100 text-blue-700'
+                      : s.state === 'closed'
+                      ? 'bg-green-100 text-green-700'
+                      : 'bg-gray-100 text-gray-700'
+                  }`}
+                >
+                  {s.state}
+                </Badge>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center h-64 text-muted-foreground">
+          Loading burndown data…
+        </div>
+      )}
+
+      {error && (
+        <div className="flex items-center justify-center h-64 text-destructive text-sm">
+          Failed to load burndown data.
+        </div>
+      )}
+
+      {!isLoading && !error && burndown && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Burndown — {burndown.sprintName}
+            </CardTitle>
+            <CardDescription>
+              {burndown.startDate} → {burndown.endDate}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={320}>
+              <LineChart data={burndown.dataPoints} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                <YAxis yAxisId="left" tick={{ fontSize: 11 }} />
+                <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 11 }} />
+                <Tooltip />
+                <Legend />
+                <Line
+                  yAxisId="left"
+                  type="monotone"
+                  dataKey="remainingStoryPoints"
+                  name="Story Points"
+                  stroke="#6366f1"
+                  strokeWidth={2}
+                  dot={false}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="remainingIssueCount"
+                  name="Issues"
+                  stroke="#22c55e"
+                  strokeWidth={2}
+                  dot={false}
+                  strokeDasharray="4 2"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && !error && !burndown && !selectedSprintId && (
+        <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+          Select a sprint to view its burndown chart.
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Velocity Tab ─────────────────────────────────────────────────────────────
+const VelocityTab: React.FC<{ projectId: string }> = ({ projectId }) => {
+  const { data: velocity, isLoading, error } = useQuery({
+    queryKey: ['velocity', projectId],
+    queryFn: () => reportService.getVelocity(projectId),
+    enabled: !!projectId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        Loading velocity data…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-64 text-destructive text-sm">
+        Failed to load velocity data.
+      </div>
+    );
+  }
+
+  const data = velocity?.velocityData ?? [];
+
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+        No closed sprints yet. Velocity data will appear after the first sprint is closed.
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Velocity — Last {data.length} Sprints</CardTitle>
+        <CardDescription>Completed story points and issues per sprint</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={320}>
+          <BarChart data={data} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="sprintName" tick={{ fontSize: 11 }} />
+            <YAxis yAxisId="left" tick={{ fontSize: 11 }} />
+            <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 11 }} />
+            <Tooltip />
+            <Legend />
+            <Bar
+              yAxisId="left"
+              dataKey="completedStoryPoints"
+              name="Story Points"
+              fill="#6366f1"
+              radius={[3, 3, 0, 0]}
+            />
+            <Bar
+              yAxisId="right"
+              dataKey="completedIssueCount"
+              name="Issues"
+              fill="#22c55e"
+              radius={[3, 3, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+};
+
+// ─── Issue Stats Tab ──────────────────────────────────────────────────────────
+const IssueStatsTab: React.FC<{ projectId: string }> = ({ projectId }) => {
+  const { data: stats, isLoading, error } = useQuery({
+    queryKey: ['issue-stats', projectId],
+    queryFn: () => reportService.getIssueStats(projectId),
+    enabled: !!projectId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        Loading issue stats…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-64 text-destructive text-sm">
+        Failed to load issue stats.
+      </div>
+    );
+  }
+
+  if (!stats) return null;
+
+  const typeData = Object.entries(stats.byIssueType).map(([name, value]) => ({ name, value }));
+  const statusData = Object.entries(stats.byStatus).map(([name, value]) => ({ name, value }));
+  const priorityData = Object.entries(stats.byPriority).map(([name, value]) => ({
+    name,
+    value,
+    fill: priorityColor[name] ?? '#6366f1',
+  }));
+
+  return (
+    <div className="space-y-6">
+      {/* Summary row */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        <Card>
+          <CardContent className="pt-4">
+            <p className="text-2xl font-bold">{stats.total}</p>
+            <p className="text-xs text-muted-foreground mt-1">Total Issues</p>
+          </CardContent>
+        </Card>
+        {typeData.map(({ name, value }) => (
+          <Card key={name}>
+            <CardContent className="pt-4">
+              <p className="text-2xl font-bold">{value}</p>
+              <p className="text-xs text-muted-foreground mt-1 capitalize">{name}s</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {/* By Status */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">By Status</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={200}>
+              <PieChart>
+                <Pie
+                  data={statusData}
+                  dataKey="value"
+                  nameKey="name"
+                  cx="50%"
+                  cy="50%"
+                  outerRadius={70}
+                  label={({ name, percent }) =>
+                    `${name} ${(percent * 100).toFixed(0)}%`
+                  }
+                  labelLine={false}
+                >
+                  {statusData.map((_, index) => (
+                    <Cell key={index} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        {/* By Priority */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">By Priority</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart data={priorityData} layout="vertical" margin={{ left: 10 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis type="number" tick={{ fontSize: 11 }} />
+                <YAxis dataKey="name" type="category" tick={{ fontSize: 11 }} width={60} />
+                <Tooltip />
+                <Bar dataKey="value" name="Issues" radius={[0, 3, 3, 0]}>
+                  {priorityData.map((entry, index) => (
+                    <Cell key={index} fill={entry.fill} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        {/* By Issue Type */}
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">By Type</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart data={typeData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 11 }} />
+                <Tooltip />
+                <Bar dataKey="value" name="Issues" radius={[3, 3, 0, 0]}>
+                  {typeData.map((_, index) => (
+                    <Cell key={index} fill={COLORS[index % COLORS.length]} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+const ReportsPage: React.FC = () => {
+  const { id: projectId } = useParams<{ id: string }>();
+
+  if (!projectId) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        No project selected.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Reports</h1>
+        <p className="text-sm text-muted-foreground">
+          Sprint burndown, velocity, and issue statistics
+        </p>
+      </div>
+
+      <Tabs defaultValue="burndown">
+        <TabsList>
+          <TabsTrigger value="burndown">Burndown</TabsTrigger>
+          <TabsTrigger value="velocity">Velocity</TabsTrigger>
+          <TabsTrigger value="issue-stats">Issue Stats</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="burndown" className="mt-4">
+          <BurndownTab projectId={projectId} />
+        </TabsContent>
+
+        <TabsContent value="velocity" className="mt-4">
+          <VelocityTab projectId={projectId} />
+        </TabsContent>
+
+        <TabsContent value="issue-stats" className="mt-4">
+          <IssueStatsTab projectId={projectId} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+};
+
+export default ReportsPage;

--- a/frontend/src/services/issueService.ts
+++ b/frontend/src/services/issueService.ts
@@ -138,3 +138,65 @@ export const sprintService = {
     if (!response.success) throw new Error(response.message || 'Failed to add issue to sprint');
   },
 };
+
+// ─── Report types ────────────────────────────────────────────────────────────
+
+export interface BurndownDataPoint {
+  date: string;
+  remainingStoryPoints: number;
+  remainingIssueCount: number;
+}
+
+export interface BurndownReport {
+  sprintId: string;
+  sprintName: string;
+  startDate: string;
+  endDate: string;
+  state: string;
+  dataPoints: BurndownDataPoint[];
+}
+
+export interface VelocityDataPoint {
+  sprintId: string;
+  sprintName: string;
+  startDate: string | null;
+  endDate: string | null;
+  completedStoryPoints: number;
+  completedIssueCount: number;
+}
+
+export interface VelocityReport {
+  projectId: string;
+  velocityData: VelocityDataPoint[];
+}
+
+export interface IssueStatsReport {
+  projectId: string;
+  total: number;
+  byIssueType: Record<string, number>;
+  byStatus: Record<string, number>;
+  byPriority: Record<string, number>;
+  byAssigneeId: Record<string, number>;
+}
+
+export const reportService = {
+  async getBurndown(projectId: string, sprintId: string): Promise<BurndownReport> {
+    const response = await apiClient.get<BurndownReport>(
+      `/projects/${projectId}/reports/burndown?sprintId=${sprintId}`
+    );
+    if (!response.success || !response.data) throw new Error(response.message || 'Failed to fetch burndown');
+    return response.data;
+  },
+
+  async getVelocity(projectId: string): Promise<VelocityReport> {
+    const response = await apiClient.get<VelocityReport>(`/projects/${projectId}/reports/velocity`);
+    if (!response.success || !response.data) throw new Error(response.message || 'Failed to fetch velocity');
+    return response.data;
+  },
+
+  async getIssueStats(projectId: string): Promise<IssueStatsReport> {
+    const response = await apiClient.get<IssueStatsReport>(`/projects/${projectId}/reports/issue-stats`);
+    if (!response.success || !response.data) throw new Error(response.message || 'Failed to fetch issue stats');
+    return response.data;
+  },
+};


### PR DESCRIPTION
This pull request adds comprehensive reporting capabilities to the project management application, including backend API endpoints, service logic, frontend service integration, and routing for sprint and project reports. The main focus is to provide burndown charts, velocity charts, and issue statistics for projects and sprints, which are essential for Agile project tracking and reporting.

**Backend: Sprint & Project Reporting**

* Introduced new API endpoints in `reportRoutes.ts` to provide burndown, velocity, and issue statistics reports for projects and sprints. These endpoints are secured with authentication middleware and return formatted API responses.
* Implemented report generation logic in `dashboardService.ts`:
  - [`getBurndown`](diffhunk://#diff-d66ad31f67a614bc595c99565b502522c65bfd0b18cec392ffc5526981c96a23R1096-R1260): Computes daily remaining story points and issue counts for a sprint, supporting burndown chart data.
  - [`getVelocity`](diffhunk://#diff-d66ad31f67a614bc595c99565b502522c65bfd0b18cec392ffc5526981c96a23R1096-R1260): Returns completed story points and issue counts for the last 10 closed sprints for velocity charting.
  - [`getIssueStats`](diffhunk://#diff-d66ad31f67a614bc595c99565b502522c65bfd0b18cec392ffc5526981c96a23R1096-R1260): Aggregates issue counts by type, status, priority, and assignee for project-wide statistics.
* Registered the new report routes in the main Express server (`server.ts`). [[1]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR34) [[2]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR115)

**Frontend: Report Integration**

* Added TypeScript interfaces and a `reportService` in `issueService.ts` to fetch and type-check burndown, velocity, and issue stats reports from the backend.
* Integrated a new `ReportsPage` and React router route to display reports within the project UI. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR26) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR84)