### PR TITLE
Add API methods for managing attachments

### DIFF
--- a/frontend/src/services/issueService.ts
+++ b/frontend/src/services/issueService.ts
@@ -1,5 +1,17 @@
 import { apiClient } from './api';
 
+export interface Attachment {
+  _id: string;
+  issueId: string;
+  uploadedBy: string;
+  filename: string;
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  storagePath: string;
+  createdAt: string;
+}
+
 export interface Issue {
   _id: string;
   issueKey: string;
@@ -105,6 +117,25 @@ export const issueService = {
     const response = await apiClient.post(`/issues/${issueId}/comments`, { content });
     if (!response.success || !response.data) throw new Error(response.message || 'Failed to add comment');
     return response.data;
+  },
+
+  // ── Attachments ─────────────────────────────────────────────────────────────
+
+  async getAttachments(issueId: string): Promise<Attachment[]> {
+    const response = await apiClient.get<Attachment[]>(`/issues/${issueId}/attachments`);
+    if (!response.success || !response.data) throw new Error(response.message || 'Failed to fetch attachments');
+    return response.data;
+  },
+
+  async uploadAttachment(issueId: string, file: File): Promise<Attachment> {
+    const response = await apiClient.uploadFile<Attachment>(`/issues/${issueId}/attachments`, file);
+    if (!response.success || !response.data) throw new Error(response.message || 'Upload failed');
+    return response.data;
+  },
+
+  async deleteAttachment(issueId: string, attachmentId: string): Promise<void> {
+    const response = await apiClient.delete(`/issues/${issueId}/attachments/${attachmentId}`);
+    if (!response.success) throw new Error(response.message || 'Failed to delete attachment');
   },
 };
 


### PR DESCRIPTION
This pull request adds support for managing attachments related to issues in the `issueService`. The main changes introduce a new `Attachment` interface and three new service methods for fetching, uploading, and deleting attachments.

**Attachment support for issues:**

* Added an `Attachment` interface to define the structure of attachment objects, including fields such as `_id`, `issueId`, `filename`, and metadata like `mimeType` and `sizeBytes` (`frontend/src/services/issueService.ts`).
* Added three new methods to `issueService`:
  * [`getAttachments(issueId)`](diffhunk://#diff-30f2a5f6a35cf6f91f4bc4816e1459ec81e4f5ded1a34ad60fb7eef43023725dR121-R139): Fetches all attachments for a given issue (`frontend/src/services/issueService.ts`).
  * `uploadAttachment(issueId, file)`: Uploads a file as an attachment to a given issue (`frontend/src/services/issueService.ts`).
  * `deleteAttachment(issueId, attachmentId)`: Deletes a specific attachment from an issue (`frontend/src/services/issueService.ts`).